### PR TITLE
feat(bridge): item + ActiveEffect hooks for live GM screen updates

### DIFF
--- a/vtmtools-bridge/scripts/foundry-actions/actor.js
+++ b/vtmtools-bridge/scripts/foundry-actions/actor.js
@@ -1,7 +1,7 @@
 // Foundry actor.* helper executors.
 // See docs/superpowers/specs/2026-04-26-foundry-helper-library-roadmap.md.
 
-import { actorToWire, hookActorChanges, hookItemChanges } from "../translate.js";
+import { actorToWire, hookActorChanges, hookItemChanges, hookEffectChanges } from "../translate.js";
 
 const MODULE_ID = "vtmtools-bridge";
 
@@ -27,6 +27,7 @@ export const actorsSubscriber = {
     }
     hookActorChanges(socket);
     hookItemChanges(socket);
+    hookEffectChanges(socket);
     _attached = { socket };
   },
 

--- a/vtmtools-bridge/scripts/foundry-actions/actor.js
+++ b/vtmtools-bridge/scripts/foundry-actions/actor.js
@@ -1,7 +1,7 @@
 // Foundry actor.* helper executors.
 // See docs/superpowers/specs/2026-04-26-foundry-helper-library-roadmap.md.
 
-import { actorToWire, hookActorChanges } from "../translate.js";
+import { actorToWire, hookActorChanges, hookItemChanges } from "../translate.js";
 
 const MODULE_ID = "vtmtools-bridge";
 
@@ -26,6 +26,7 @@ export const actorsSubscriber = {
       console.log(`[${MODULE_ID}] actorsSubscriber: pushed ${actors.length} actors`);
     }
     hookActorChanges(socket);
+    hookItemChanges(socket);
     _attached = { socket };
   },
 

--- a/vtmtools-bridge/scripts/translate.js
+++ b/vtmtools-bridge/scripts/translate.js
@@ -53,3 +53,23 @@ export function hookActorChanges(socket) {
     });
   }
 }
+
+export function hookItemChanges(socket) {
+  for (const ev of ["createItem", "updateItem", "deleteItem"]) {
+    Hooks.on(ev, (item) => {
+      if (!socket || socket.readyState !== WebSocket.OPEN) return;
+      const actor = item?.parent;
+      // Skip world-directory items (parent === null) and the theoretical
+      // case of an item embedded somewhere other than an Actor.
+      if (!actor || actor.documentName !== "Actor") return;
+      try {
+        socket.send(JSON.stringify({
+          type: "actor_update",
+          actor: actorToWire(actor),
+        }));
+      } catch (e) {
+        console.warn(`[${MODULE_ID}] failed to push ${ev}:`, e);
+      }
+    });
+  }
+}

--- a/vtmtools-bridge/scripts/translate.js
+++ b/vtmtools-bridge/scripts/translate.js
@@ -73,3 +73,30 @@ export function hookItemChanges(socket) {
     });
   }
 }
+
+export function hookEffectChanges(socket) {
+  for (const ev of ["createActiveEffect", "updateActiveEffect", "deleteActiveEffect"]) {
+    Hooks.on(ev, (effect) => {
+      if (!socket || socket.readyState !== WebSocket.OPEN) return;
+      // Effect parent can be either an Actor (actor-level effect) or an Item
+      // (item-attached effect, in which case the Actor is the item's parent).
+      // Skip world-level effects and any other unexpected attachment.
+      const parent = effect?.parent;
+      let actor = null;
+      if (parent?.documentName === "Actor") {
+        actor = parent;
+      } else if (parent?.documentName === "Item" && parent.parent?.documentName === "Actor") {
+        actor = parent.parent;
+      }
+      if (!actor) return;
+      try {
+        socket.send(JSON.stringify({
+          type: "actor_update",
+          actor: actorToWire(actor),
+        }));
+      } catch (e) {
+        console.warn(`[${MODULE_ID}] failed to push ${ev}:`, e);
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- Subscribe to Foundry's `createItem` / `updateItem` / `deleteItem` hooks and emit `actor_update` wire messages so item-level changes (merits added, bonuses edited, merits removed) propagate to the vtmtools GM screen within ~1s.
- Subscribe to `createActiveEffect` / `updateActiveEffect` / `deleteActiveEffect` hooks for the same reason. Effect parent can be an Actor (direct) or an Item (walk up one level).
- Reuses the existing `actor_update` shape — backend already treats it as authoritative actor state.

Before this change, the bridge only pushed on `updateActor`, so item/effect mutations left the GM screen stale until a full reload.

Known follow-up (separate branch, brainstormed but not yet implemented): when an item-bound `CharacterModifier` row outlives its live item, the card still renders as a stale orphan. Fix is specced in `docs/superpowers/specs/2026-05-13-gm-screen-live-data-priority-design.md` (local, gitignored) — relies on this branch as the hook substrate.

## Test plan

- [x] `./scripts/verify.sh` green pre-commit on both tasks
- [x] Smoke-tested locally: add merit on Foundry sheet → new card appears within ~1s
- [x] Smoke-tested locally: edit bonus value → card line updates within ~1s
- [x] Smoke-tested locally: delete merit (no override) → card disappears within ~1s
- [x] Smoke-tested locally: ActiveEffect mutations propagate to GM screen
- [x] World-directory items and effects with no Actor parent are silently skipped (existing pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)