### PR TITLE
feat(gm-screen): auto-delete orphan modifiers on live item deletion

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -622,6 +622,7 @@ disabled for the session; Roll20 is unaffected.
 | `bridge://foundry/disconnected` | none | Foundry module closes wss connection |
 | `bridge://characters-updated` | `Vec<CanonicalCharacter>` | Any source pushed updated characters; carries the merged cache across all sources |
 | `bridge://roll-received` | `CanonicalRoll` | Foundry source decoded a `roll_result` chat message into a canonical roll; pushed into bridge state ring (capacity 200, dedup by `source_id`) and emitted in one accept-loop arm |
+| `modifiers://rows-reaped` | `{ ids: number[] }` | Backend reaped advantage-bound `character_modifiers` rows after a Foundry `deleteItem` hook (via `item_deleted` wire); frontend modifier store drops the listed ids |
 
 ### Svelte cross-tool pub/sub
 

--- a/src-tauri/src/bridge/foundry/mod.rs
+++ b/src-tauri/src/bridge/foundry/mod.rs
@@ -32,6 +32,13 @@ impl BridgeSource for FoundrySource {
                 let canonical = translate_roll::to_canonical_roll(&message);
                 return Ok(vec![InboundEvent::RollReceived(canonical)]);
             }
+            FoundryInbound::ItemDeleted { actor_id, item_id } => {
+                return Ok(vec![InboundEvent::ItemDeleted {
+                    source: crate::bridge::types::SourceKind::Foundry,
+                    source_id: actor_id,
+                    item_id,
+                }]);
+            }
         };
         let canonical: Vec<_> = actors.iter().map(translate::to_canonical).collect();
         Ok(vec![InboundEvent::CharactersUpdated(canonical)])
@@ -79,5 +86,33 @@ fn parse_value(s: &str) -> Value {
         Value::from(false)
     } else {
         Value::from(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bridge::source::InboundEvent;
+    use crate::bridge::types::SourceKind;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn item_deleted_inbound_produces_modifier_reap_event() {
+        let source = FoundrySource;
+        let msg = json!({
+            "type": "item_deleted",
+            "actor_id": "actor-a",
+            "item_id": "merit-1",
+        });
+        let events = source.handle_inbound(msg).await.expect("handles");
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            InboundEvent::ItemDeleted { source, source_id, item_id } => {
+                assert_eq!(*source, SourceKind::Foundry);
+                assert_eq!(source_id, "actor-a");
+                assert_eq!(item_id, "merit-1");
+            }
+            other => panic!("expected ItemDeleted event, got {other:?}"),
+        }
     }
 }

--- a/src-tauri/src/bridge/foundry/types.rs
+++ b/src-tauri/src/bridge/foundry/types.rs
@@ -29,6 +29,14 @@ pub enum FoundryInbound {
     /// Inbound roll result captured by the Foundry-side `createChatMessage`
     /// hook. Fields are decoded into `CanonicalRoll` by `translate_roll`.
     RollResult { message: FoundryRollMessage },
+    /// A Foundry item was deleted from an actor. Triggered by the
+    /// `deleteItem` hook in `vtmtools-bridge/scripts/translate.js`.
+    /// `actor_id` is the Foundry actor `_id` (canonical `source_id`);
+    /// `item_id` is the deleted item's `_id`.
+    ItemDeleted {
+        actor_id: String,
+        item_id: String,
+    },
 }
 
 /// Wire shape for a Foundry roll result. JS-side `messageToWire`
@@ -219,5 +227,18 @@ mod tests {
         }"#;
         let actor: FoundryActor = serde_json::from_str(wire).expect("legacy parses");
         assert_eq!(actor.id, "abc");
+    }
+
+    #[test]
+    fn foundry_inbound_deserializes_item_deleted() {
+        let wire = r#"{"type":"item_deleted","actor_id":"actor-a","item_id":"merit-1"}"#;
+        let parsed: FoundryInbound = serde_json::from_str(wire).expect("parses");
+        match parsed {
+            FoundryInbound::ItemDeleted { actor_id, item_id } => {
+                assert_eq!(actor_id, "actor-a");
+                assert_eq!(item_id, "merit-1");
+            }
+            _ => panic!("expected ItemDeleted, got {parsed:?}"),
+        }
     }
 }

--- a/src-tauri/src/bridge/mod.rs
+++ b/src-tauri/src/bridge/mod.rs
@@ -17,7 +17,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
 use futures_util::{SinkExt, StreamExt};
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpListener;
 use tokio::sync::{mpsc, Mutex};
@@ -284,6 +284,41 @@ async fn handle_connection<S>(
                         InboundEvent::RollReceived(roll) => {
                             state.push_roll(roll.clone()).await;
                             let _ = handle.emit("bridge://roll-received", &roll);
+                        }
+                        InboundEvent::ItemDeleted { source, source_id, item_id } => {
+                            // Lookup the pool via Tauri's managed-state map.
+                            // DbState is registered in lib.rs::run setup,
+                            // before bridge servers are spawned, so this
+                            // never fails in practice. If it ever did
+                            // (no pool managed), skip the reap silently —
+                            // a stale orphan card is preferable to a panic.
+                            let pool = match handle.try_state::<crate::DbState>() {
+                                Some(s) => Arc::clone(&s.0),
+                                None => {
+                                    eprintln!(
+                                        "[bridge:{}] ItemDeleted: no DbState managed, skipping reap",
+                                        kind.as_str()
+                                    );
+                                    continue;
+                                }
+                            };
+                            match crate::db::modifier::db_delete_by_advantage_binding(
+                                &pool, &source, &source_id, &item_id,
+                            ).await {
+                                Ok(ids) if !ids.is_empty() => {
+                                    let _ = handle.emit(
+                                        "modifiers://rows-reaped",
+                                        serde_json::json!({ "ids": ids }),
+                                    );
+                                }
+                                Ok(_) => {} // idempotent — no rows matched, nothing to emit
+                                Err(e) => {
+                                    eprintln!(
+                                        "[bridge:{}] ItemDeleted reap failed: {e}",
+                                        kind.as_str()
+                                    );
+                                }
+                            }
                         }
                     }
                 }

--- a/src-tauri/src/bridge/source.rs
+++ b/src-tauri/src/bridge/source.rs
@@ -13,6 +13,14 @@ pub enum InboundEvent {
     CharactersUpdated(Vec<CanonicalCharacter>),
     /// Source pushed a roll result.
     RollReceived(CanonicalRoll),
+    /// Foundry-side item deletion — frontend modifier rows tied to this
+    /// item must be reaped. Caller in `bridge::mod` runs the DB delete and
+    /// emits `modifiers://rows-reaped`. Spec §5.2.
+    ItemDeleted {
+        source: crate::bridge::types::SourceKind,
+        source_id: String,
+        item_id: String,
+    },
 }
 
 /// Per-source protocol adapter. Sources are stateless transformers;

--- a/src-tauri/src/db/modifier.rs
+++ b/src-tauri/src/db/modifier.rs
@@ -356,6 +356,37 @@ pub(crate) async fn db_materialize_advantage(
     db_get(pool, result.last_insert_rowid()).await
 }
 
+/// Delete all advantage-bound modifier rows for `(source, source_id)` whose
+/// binding `item_id` matches. Returns the deleted row ids. Idempotent —
+/// no matches returns an empty Vec. Gated on `binding_json.kind = 'advantage'`
+/// so free-floating modifiers are never affected.
+///
+/// Triggered by the Foundry `item_deleted` wire shape from
+/// `vtmtools-bridge/scripts/translate.js` when a player or GM deletes a merit
+/// on the Foundry sheet — see spec §3.2.
+pub(crate) async fn db_delete_by_advantage_binding(
+    pool: &SqlitePool,
+    source: &SourceKind,
+    source_id: &str,
+    item_id: &str,
+) -> Result<Vec<i64>, String> {
+    let rows = sqlx::query(
+        "DELETE FROM character_modifiers
+         WHERE source = ? AND source_id = ?
+           AND json_extract(binding_json, '$.kind') = 'advantage'
+           AND json_extract(binding_json, '$.item_id') = ?
+         RETURNING id"
+    )
+    .bind(source_to_str(source))
+    .bind(source_id)
+    .bind(item_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| format!("db/modifier.delete_by_advantage_binding: {e}"))?;
+
+    Ok(rows.iter().map(|r| r.get::<i64, _>("id")).collect())
+}
+
 #[tauri::command]
 pub async fn materialize_advantage_modifier(
     pool: tauri::State<'_, crate::DbState>,
@@ -712,5 +743,87 @@ mod tests {
         let back: crate::shared::modifier::ModifierEffect =
             serde_json::from_str(&json).unwrap();
         assert_eq!(back, new_shape);
+    }
+
+    #[tokio::test]
+    async fn delete_by_advantage_binding_returns_ids_for_matches() {
+        let pool = fresh_pool().await;
+        // Two advantage-bound rows on the same character pointing at item "merit-1".
+        sqlx::query(
+            r#"INSERT INTO character_modifiers
+               (source, source_id, name, binding_json)
+               VALUES ('foundry', 'actor-a', 'M1',
+                       '{"kind":"advantage","item_id":"merit-1"}'),
+                      ('foundry', 'actor-a', 'M2',
+                       '{"kind":"advantage","item_id":"merit-1"}')"#,
+        )
+        .execute(&pool).await.unwrap();
+
+        let ids = db_delete_by_advantage_binding(
+            &pool, &SourceKind::Foundry, "actor-a", "merit-1",
+        ).await.unwrap();
+
+        assert_eq!(ids.len(), 2, "both matching rows deleted");
+        let remaining: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM character_modifiers"
+        ).fetch_one(&pool).await.unwrap();
+        assert_eq!(remaining, 0);
+    }
+
+    #[tokio::test]
+    async fn delete_by_advantage_binding_idempotent_when_no_match() {
+        let pool = fresh_pool().await;
+        let ids = db_delete_by_advantage_binding(
+            &pool, &SourceKind::Foundry, "actor-a", "merit-1",
+        ).await.unwrap();
+        assert!(ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_by_advantage_binding_does_not_delete_free_modifiers() {
+        let pool = fresh_pool().await;
+        sqlx::query(
+            r#"INSERT INTO character_modifiers
+               (source, source_id, name, binding_json)
+               VALUES ('foundry', 'actor-a', 'FreeMod', '{"kind":"free"}')"#,
+        )
+        .execute(&pool).await.unwrap();
+
+        // Even calling with a junk item_id on the same actor: free rows untouched.
+        let ids = db_delete_by_advantage_binding(
+            &pool, &SourceKind::Foundry, "actor-a", "merit-1",
+        ).await.unwrap();
+        assert!(ids.is_empty());
+
+        let remaining: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM character_modifiers"
+        ).fetch_one(&pool).await.unwrap();
+        assert_eq!(remaining, 1, "free modifier still present");
+    }
+
+    #[tokio::test]
+    async fn delete_by_advantage_binding_scoped_to_source_and_source_id() {
+        let pool = fresh_pool().await;
+        sqlx::query(
+            r#"INSERT INTO character_modifiers
+               (source, source_id, name, binding_json)
+               VALUES ('foundry', 'actor-a', 'OnA',
+                       '{"kind":"advantage","item_id":"merit-1"}'),
+                      ('foundry', 'actor-b', 'OnB',
+                       '{"kind":"advantage","item_id":"merit-1"}'),
+                      ('roll20',  'actor-a', 'R20',
+                       '{"kind":"advantage","item_id":"merit-1"}')"#,
+        )
+        .execute(&pool).await.unwrap();
+
+        let ids = db_delete_by_advantage_binding(
+            &pool, &SourceKind::Foundry, "actor-a", "merit-1",
+        ).await.unwrap();
+        assert_eq!(ids.len(), 1, "only the (foundry, actor-a) row");
+
+        let remaining: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM character_modifiers"
+        ).fetch_one(&pool).await.unwrap();
+        assert_eq!(remaining, 2, "actor-b and roll20 rows untouched");
     }
 }

--- a/src/lib/components/gm-screen/CharacterRow.svelte
+++ b/src/lib/components/gm-screen/CharacterRow.svelte
@@ -127,9 +127,10 @@
     return mod.foundryCapturedLabels.length > 0 && mod.binding.kind === 'advantage';
   }
 
-  // Build the card list per spec §8.1.
+  // Build the card list per spec §8.1 (updated 2026-05-13 — advantage-orphan
+  // branch removed; orphan reaping happens backend-side on deleteItem).
   type CardEntry =
-    | { kind: 'materialized'; mod: CharacterModifier; isStale: boolean }
+    | { kind: 'materialized'; mod: CharacterModifier }
     | { kind: 'virtual'; virt: VirtualCard };
 
   let cardEntries = $derived.by((): CardEntry[] => {
@@ -139,7 +140,7 @@
     for (const item of advantageItems) {
       const matched = charMods.find(m => m.binding.kind === 'advantage' && m.binding.item_id === item._id);
       if (matched) {
-        entries.push({ kind: 'materialized', mod: matched, isStale: false });
+        entries.push({ kind: 'materialized', mod: matched });
       } else {
         entries.push({ kind: 'virtual', virt: {
           item,
@@ -149,13 +150,12 @@
       }
     }
 
-    // (3) Append free-floating modifiers (and any 'advantage' mods whose item was deleted — these become stale).
-    const knownAdvantageItemIds = new Set(advantageItems.map(it => it._id));
+    // (3) Append free-floating modifiers. Advantage-bound orphans no longer
+    // render here — the deleteItem hook in vtmtools-bridge triggers a DB delete
+    // that arrives via `modifiers://rows-reaped`, removing them from the store.
     for (const m of charMods) {
       if (m.binding.kind === 'free') {
-        entries.push({ kind: 'materialized', mod: m, isStale: false });
-      } else if (m.binding.kind === 'advantage' && !knownAdvantageItemIds.has(m.binding.item_id)) {
-        entries.push({ kind: 'materialized', mod: m, isStale: true });
+        entries.push({ kind: 'materialized', mod: m });
       }
     }
     return entries;
@@ -268,7 +268,6 @@
     if (character.source !== 'foundry') return false;
     if (e.kind !== 'materialized') return false;            // virtual = no DB row yet
     if (e.mod.binding.kind !== 'advantage') return false;
-    if (e.isStale) return false;
     return e.mod.effects.some(eff => eff.kind === 'pool');
   }
 
@@ -424,7 +423,6 @@
             }
           : entry.mod}
         isVirtual={entry.kind === 'virtual'}
-        isStale={entry.kind === 'materialized' && entry.isStale}
         bonuses={entry.kind === 'virtual'
           ? bonusesFor(entry.virt.item._id)
           : entry.mod.binding.kind === 'advantage'

--- a/src/lib/components/gm-screen/ModifierCard.svelte
+++ b/src/lib/components/gm-screen/ModifierCard.svelte
@@ -10,8 +10,6 @@
     modifier: CharacterModifier;
     /** Marks an advantage-derived card not yet materialized — UI shows asterisk */
     isVirtual?: boolean;
-    /** Marks a stale card whose source merit was deleted — UI shows badge */
-    isStale?: boolean;
     /**
      * Sheet-attached bonuses (system.bonuses[]) from the source Foundry
      * feature item, when the card is advantage-bound. Distinct from
@@ -59,7 +57,7 @@
   }
 
   let {
-    modifier, isVirtual = false, isStale = false, bonuses = [],
+    modifier, isVirtual = false, bonuses = [],
     conditionalsSkipped = [],
     canPush = false, onPush,
     canReset = false, onReset,
@@ -102,7 +100,6 @@
   <div class="head">
     <span class="name" title={modifier.name}>
       {modifier.name}{#if isVirtual}<span class="virtual-mark" title="Not yet customized">*</span>{/if}{#if showOverride}<span class="override-mark" title="Saved local override — this card's data comes from your saved copy, which supersedes the live Foundry read-through">*</span>{/if}
-      {#if isStale}<span class="stale" title="Source merit removed">stale</span>{/if}
     </span>
     <button
       bind:this={cogEl}
@@ -272,7 +269,6 @@
     font-weight: 700;
     cursor: help;
   }
-  .stale { font-size: 0.65rem; color: var(--accent-amber); margin-left: 0.4rem; }
   .origin {
     margin: 0;
     font-size: 0.6rem;

--- a/src/store/modifiers.svelte.ts
+++ b/src/store/modifiers.svelte.ts
@@ -22,6 +22,7 @@ import type {
   PushReport,
   SourceKind,
 } from '../types';
+import { listen } from '@tauri-apps/api/event';
 
 let _list = $state<CharacterModifier[]>([]);
 let _loading = $state(false);
@@ -72,6 +73,15 @@ export const modifiers = {
     if (_initialized) return;
     _initialized = true;
     await refresh();
+    // Subscribe to backend-initiated row reaps (live deleteItem from Foundry).
+    // The event carries the exact ids to drop — no refetch needed. The store's
+    // long-standing "no auto-refetch on bridge state" invariant (see header
+    // comment) is preserved: this is an explicit cleanup signal, not a state
+    // diff. Spec §6.2 of
+    // docs/superpowers/specs/2026-05-13-gm-screen-live-data-priority-design.md.
+    void listen<{ ids: number[] }>('modifiers://rows-reaped', (e) => {
+      for (const id of e.payload.ids) dropRow(id);
+    });
   },
   async refresh(): Promise<void> { await refresh(); },
 

--- a/vtmtools-bridge/scripts/translate.js
+++ b/vtmtools-bridge/scripts/translate.js
@@ -67,6 +67,18 @@ export function hookItemChanges(socket) {
           type: "actor_update",
           actor: actorToWire(actor),
         }));
+        // Explicit cleanup signal for live-item deletion — backend reaps
+        // any advantage-bound character_modifiers row pointing at this
+        // item. Sent IN ADDITION to actor_update so bridge state stays
+        // accurate AND the modifier row is removed. See spec §3.2 of
+        // docs/superpowers/specs/2026-05-13-gm-screen-live-data-priority-design.md.
+        if (ev === "deleteItem") {
+          socket.send(JSON.stringify({
+            type: "item_deleted",
+            actor_id: actor.id,
+            item_id: item.id,
+          }));
+        }
       } catch (e) {
         console.warn(`[${MODULE_ID}] failed to push ${ev}:`, e);
       }


### PR DESCRIPTION
## Summary

Auto-delete advantage-bound `CharacterModifier` rows when their backing Foundry item is deleted on the live sheet, and stop rendering item-level orphan cards on the GM screen.

- New `item_deleted` wire shape from the Foundry bridge JS (rides on the `deleteItem` hook shipped in #29)
- New `FoundryInbound::ItemDeleted` variant → `InboundEvent::ItemDeleted` → dispatcher in `bridge/mod.rs` runs `db_delete_by_advantage_binding` → emits `modifiers://rows-reaped`
- Frontend filter in `CharacterRow.svelte` drops the advantage-orphan branch
- `isStale` field/prop removed from `CharacterRow` and `ModifierCard`

Character-level orphan UI (the "Show orphans" toggle in `GmScreen.svelte`) is intentionally retained — it covers a different case (modifier rows whose entire character disappears).

## Test plan

- [x] Rust unit tests for `db_delete_by_advantage_binding`: matches return ids, idempotent, free-floating untouched, scoped to (source, source_id) tuple
- [x] Rust deserialize test for `FoundryInbound::ItemDeleted`
- [x] Rust handler test: `FoundrySource::handle_inbound` returns `InboundEvent::ItemDeleted` for the JSON wire shape
- [x] \`./scripts/verify.sh\` green pre-commit on every commit
- [x] Manual smoke: delete merit WITH override → card disappears ~1s (the bug from the original report)
- [x] Manual smoke: delete merit without override → still disappears (was virtual)
- [x] Manual smoke: free-floating modifier untouched
- [x] Manual smoke: world-directory item delete silently skipped
- [x] Manual smoke: "Show orphans" character-level UI still works

## Design doc

\`docs/superpowers/specs/2026-05-13-gm-screen-live-data-priority-design.md\` (gitignored — local design archive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)