### PR TITLE
Phase 4: Library Sync — Plans A, B, C (schema, push, pull)

### DIFF
--- a/docs/superpowers/plans/2026-05-14-library-sync-plan-a-library-schema-foundation.md
+++ b/docs/superpowers/plans/2026-05-14-library-sync-plan-a-library-schema-foundation.md
@@ -1,0 +1,886 @@
+# Library Sync — Plan A: Library schema foundation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Project lean-execution override (CLAUDE.md):** dispatch ONE implementer subagent per task with full task text + scene-setting context, run `./scripts/verify.sh` after the implementer commits, then move on. After ALL Plan A tasks are committed, defer the `code-review:code-review` until Plan C is also done (single review across the full Phase 4 branch diff).
+>
+> **TDD-on-demand override (CLAUDE.md):** subagents do NOT auto-invoke `superpowers:test-driven-development`. Each task below explicitly states whether tests are required.
+
+**Goal:** Promote the `tags_json`-based kind discrimination on `advantages` to a real `kind` column (CHECK-gated enum) and add a nullable `source_attribution` TEXT column for FVTT-import provenance. Backfill from existing tags. Update the `Advantage` Rust struct + TS mirror + seed corpus + AdvantagesManager UI (kind chip only — source-attribution chip lands in Plan C). No FVTT bridge work in this plan.
+
+**Architecture:** Single migration on a live table using the proven `ALTER TABLE ADD COLUMN … CHECK(…)` + `UPDATE … CASE WHEN` pattern shipped in `0007_add_modifier_zone.sql`. Backfill priority for ambiguous tag combinations: `merit > flaw > background > boon` (highest priority wins). `tags_json` stays for free-form taxonomy (Feeding / Social / Supernatural / etc.) — only the kind-discriminator role moves to the new column. Existing consumers (`db/modifier.rs`, `tools/character.rs`, `db/saved_character.rs`) read the row by `id` only and do not depend on the discriminator at the DB layer, so the schema change is non-breaking for them.
+
+**Tech Stack:** Rust (`sqlx`, `serde`, `serde_json`), TypeScript / Svelte 5 runes, SQLite.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-character-tooling-roadmap.md` §5 Phase 4 (sketch), refined by the architect-advisor recommendation captured on branch `claude/brainstorm-library-features-Cf0B8` (commit at end of plan).
+
+**Architecture reference:** `ARCHITECTURE.md` §3 (Storage strategy — `is_custom` invariant), §4 (IPC inventory — touches `db::advantage::*` command surface but adds zero new commands), §6 (Invariants — destructive reseed per ADR 0002 stays intact), §9 ("Add a schema change" seam).
+
+**Depends on:** nothing.
+
+**Unblocks:** Plan B (push uses `kind` to map to `featuretype`), Plan C (pull writes `kind` + `source_attribution` directly).
+
+**Issues:** None directly — Plan A is a prerequisite that doesn't close any milestone-4 issue on its own. Cite as "Refs #13 #14 #15 (foundation)" on commits.
+
+---
+
+## File structure
+
+### New files
+- `src-tauri/migrations/0009_advantages_kind_and_source.sql` — ADD COLUMN `kind` (CHECK-gated enum) + ADD COLUMN `source_attribution` (nullable TEXT/JSON); backfill `kind` from `tags_json`.
+
+### Modified files
+- `src-tauri/src/shared/types.rs` — `Advantage` struct gains `kind: AdvantageKind` and `source_attribution: Option<serde_json::Value>`; new `AdvantageKind` enum (`Merit` / `Flaw` / `Background` / `Boon`) with `#[serde(rename_all = "snake_case")]`.
+- `src-tauri/src/db/advantage.rs` — `db_list`, `db_insert`, `db_update` thread the two new fields through. Tests updated for new struct shape; new tests for kind round-trip + source_attribution round-trip + filter-by-kind helper.
+- `src-tauri/src/db/seed.rs` — `SeedRow` struct gains `kind: AdvantageKind`; existing rows annotated (Merit/Background/Flaw — no Boons in corebook); `seed_advantages` writes `kind` on INSERT. Tag arrays unchanged (still carry the "Merit"/"Background"/"Flaw" tag for backwards-display compatibility).
+- `src/types.ts` — mirror `AdvantageKind` enum + extended `Advantage` interface.
+- `src/lib/advantages/api.ts` — `AdvantageInput` gains `kind` (required); typed wrappers thread it through.
+- `src/tools/AdvantagesManager.svelte` — render a per-row `kind` chip; add "kind" tags to the existing tag-filter row (or wire a parallel `activeKinds: Set<AdvantageKind>` filter — see Task 6 for details).
+- `src/lib/components/AdvantageForm.svelte` — add a `kind` select control (required, defaults to `merit`).
+- `ARCHITECTURE.md` — §6 invariants paragraph documenting the `is_custom` tri-state semantic shift (corebook = 0 / hand-authored local = 1 + null attribution / FVTT-imported = 1 + non-null attribution); §9 "Add a library kind" seam paragraph codifying the partitioning rule (same row shape → polymorphic table with `kind`; different row shape → own table).
+
+### Files explicitly NOT touched
+- `src-tauri/src/bridge/**` — Plan B territory
+- `src-tauri/src/tools/library_push.rs` (new) — Plan B territory
+- `src-tauri/src/db/modifier.rs::materialize_advantage_modifier` — reads advantage by `id`, doesn't depend on tag-based kind. No change needed (verify in Task 4).
+- `src-tauri/src/tools/character.rs::character_add_advantage` / `character_remove_advantage` — same reasoning.
+- `src-tauri/src/db/saved_character.rs::db_add_advantage` — already validates featuretype against `merit/flaw/background/boon` (line 226); we'll verify it still composes correctly in Task 4 but should not require changes (it takes featuretype as a parameter, not from advantage row).
+- `src/lib/saved-characters/diff.ts` — verify it doesn't depend on advantage tag strings (Task 4 audit).
+- `dyscrasias` table and `db/dyscrasia.rs` — separate row shape, deferred per partitioning rule.
+
+---
+
+## Task overview
+
+| # | Task | Depends on | Tests |
+|---|---|---|---|
+| 1 | Create migration `0009_advantages_kind_and_source.sql` + verify it applies + backfill is correct | none | YES (sqlx-migrate-runtime — verify CHECK constraint rejects bad values; verify backfill priority) |
+| 2 | Add `AdvantageKind` enum + extend `Advantage` struct in `shared/types.rs` | 1 | NO (struct definition only) |
+| 3 | Update `db/advantage.rs` to read/write the new columns + update existing tests + add new tests | 2 | YES (3 new tests minimum) |
+| 4 | Update `db/seed.rs` to write `kind` on INSERT; annotate existing seed rows | 2 | NO (seed is idempotent; covered by Task 1's runtime check) |
+| 5 | Audit non-advantage consumers for breakage; update `db/saved_character.rs::db_add_advantage` IFF audit finds a gap | 3, 4 | NO (audit task; tests only if gap found) |
+| 6 | Mirror types in `src/types.ts` + extend `src/lib/advantages/api.ts` | 3 | NO |
+| 7 | Update `AdvantagesManager.svelte` (kind chip + kind filter) + `AdvantageForm.svelte` (kind select) | 6 | NO (UI; covered by `npm run build` + manual smoke) |
+| 8 | Update `ARCHITECTURE.md` §6 (tri-state `is_custom`) + §9 ("Add a library kind") | 7 | NO |
+| 9 | Final verification gate | all | runs `./scripts/verify.sh` |
+
+Tasks 3 and 4 are independent of each other (different functions in different files) and can dispatch in parallel after Task 2. Tasks 5–8 are sequential.
+
+---
+
+## Task 1: Create migration `0009_advantages_kind_and_source.sql`
+
+**Goal:** Add `kind` (CHECK-gated, NOT NULL with default 'merit') and `source_attribution` (nullable TEXT) columns. Backfill `kind` from `tags_json` using the priority-cascade `merit > flaw > background > boon`.
+
+**Files:**
+- Create: `src-tauri/migrations/0009_advantages_kind_and_source.sql`
+
+**Anti-scope:** Do NOT touch any other migration. Do NOT alter `dyscrasias` or any other table. Do NOT drop `tags_json` — it stays as a free-form taxonomy column.
+
+**Depends on:** none
+
+**Invariants cited:** ARCHITECTURE.md §3 (migrations applied via `sqlx::migrate!`; `PRAGMA foreign_keys = ON` enabled on pool). The `ALTER TABLE … ADD COLUMN … CHECK(…)` pattern is proven in `0007_add_modifier_zone.sql`.
+
+**Tests required:** YES — the verification step rebuilds the dev DB and confirms backfill correctness.
+
+- [ ] **Step 1: Write the migration**
+
+Create `src-tauri/migrations/0009_advantages_kind_and_source.sql`:
+
+```sql
+-- Adds kind and source_attribution columns to advantages.
+--
+-- kind disambiguates the polymorphic table (Phase 4 storage decision); was
+-- previously inferred from tags_json string-matching. tags_json stays for
+-- free-form taxonomy ("Feeding", "Social", "Supernatural", "VTM 5e", etc.).
+--
+-- source_attribution carries FVTT-import provenance (Phase 4 issue #15).
+-- NULL = hand-authored locally (whether corebook seed or GM custom).
+-- Non-null = imported from a Foundry world; JSON shape:
+--   { "source": "foundry", "world_title": "...", "world_id": "...",
+--     "system_version": "...", "imported_at": "ISO-8601" }
+-- The exact shape is enforced at the application layer, not by SQLite.
+
+ALTER TABLE advantages
+    ADD COLUMN kind TEXT NOT NULL DEFAULT 'merit'
+    CHECK(kind IN ('merit', 'flaw', 'background', 'boon'));
+
+ALTER TABLE advantages
+    ADD COLUMN source_attribution TEXT;
+
+-- Backfill kind from tags_json. Priority cascade: merit > flaw > background
+-- > boon. Highest priority wins via CASE WHEN ordering (first match returns).
+-- Rows tagged with none of the four kind-strings stay at the default 'merit'.
+UPDATE advantages
+   SET kind = CASE
+       WHEN tags_json LIKE '%"Merit"%'      THEN 'merit'
+       WHEN tags_json LIKE '%"Flaw"%'       THEN 'flaw'
+       WHEN tags_json LIKE '%"Background"%' THEN 'background'
+       WHEN tags_json LIKE '%"Boon"%'       THEN 'boon'
+       ELSE 'merit'
+   END;
+```
+
+- [ ] **Step 2: Verify the migration compiles**
+
+Run: `cargo check --manifest-path src-tauri/Cargo.toml`
+
+Expected: clean. `sqlx::migrate!` is a compile-time macro that ensures all migration files parse.
+
+- [ ] **Step 3: Verify backfill correctness on a dev DB**
+
+The dev DB lives at the path returned by `app.path().app_data_dir()` (Tauri-managed). Easiest path: delete `~/.local/share/com.hampternt.vtmtools/vtmtools.db` (or whatever the dev path is — check `tauri.conf.json`), run `npm run tauri dev`, exit immediately after the world is seeded, then inspect the table:
+
+```bash
+sqlite3 ~/.local/share/com.hampternt.vtmtools/vtmtools.db \
+  "SELECT name, kind, tags_json FROM advantages ORDER BY kind, name;"
+```
+
+Expected output (verify against `seed.rs::seed_rows`):
+- 4 merits (Iron Gullet, Eat Food, Bloodhound, Beautiful) → `kind = 'merit'`
+- 4 backgrounds (Allies, Contacts, Haven, Resources) → `kind = 'background'`
+- 2 flaws (Prey Exclusion, Enemy) → `kind = 'flaw'`
+- 0 boons (no boons in V5 corebook seed)
+
+If counts mismatch: inspect `tags_json` on the affected rows; the LIKE pattern requires the tag value to be quoted in the JSON exactly as `"Merit"` / `"Flaw"` / `"Background"` / `"Boon"` — case-sensitive.
+
+- [ ] **Step 4: Run `./scripts/verify.sh`**
+
+Expected: green. Existing `db::advantage` tests still pass because `db_list` doesn't yet reference the new column (Task 3 changes that).
+
+- [ ] **Step 5: Commit**
+
+```
+git add src-tauri/migrations/0009_advantages_kind_and_source.sql
+git commit -m "$(cat <<'EOF'
+Add `kind` + `source_attribution` columns to advantages
+
+Promotes tags-based kind discrimination to a CHECK-gated column.
+Backfills `kind` from existing tags_json with priority cascade
+merit > flaw > background > boon. `tags_json` stays for free-form
+taxonomy.
+
+Foundation for Phase 4 library sync. Refs #13 #14 #15.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 2: Add `AdvantageKind` enum + extend `Advantage` struct
+
+**Goal:** Mirror the SQL CHECK enum on the Rust side as a typed `AdvantageKind`; extend the `Advantage` struct to carry `kind` + `source_attribution`.
+
+**Files:**
+- Modify: `src-tauri/src/shared/types.rs` (around line 126 where `Advantage` lives)
+
+**Anti-scope:** Do NOT change the existing `tags`/`properties` fields. Do NOT introduce a typed `SourceAttribution` struct (architect anti-recommendation: stay JSON-blob for v1; promote to typed enum when a second source materializes).
+
+**Depends on:** Task 1
+
+**Invariants cited:** ARCHITECTURE.md §3 (`shared/types.rs` is the single source of truth for cross-boundary types).
+
+**Tests required:** NO — struct definition only; runtime tests come in Task 3.
+
+- [ ] **Step 1: Add `AdvantageKind` enum**
+
+In `src-tauri/src/shared/types.rs`, immediately before the `pub struct Advantage` block (around line 124), add:
+
+```rust
+/// Kind discriminator for the polymorphic `advantages` library table.
+/// Mirrors the SQL CHECK constraint in `0009_advantages_kind_and_source.sql`.
+///
+/// Partitioning rule (ARCHITECTURE.md §9): same row shape → same table with
+/// kind; different row shape → own table. The four variants here share the
+/// Advantage row shape AND the `actor.create_feature` push contract
+/// (foundry helper roadmap §5). Dyscrasias and (future) disciplines have
+/// different row shapes and get their own tables.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AdvantageKind {
+    Merit,
+    Flaw,
+    Background,
+    Boon,
+}
+```
+
+- [ ] **Step 2: Extend the `Advantage` struct**
+
+Edit the existing `pub struct Advantage` block:
+
+```rust
+/// A library entry for a VTM 5e Merit, Background, Flaw, or Boon.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Advantage {
+    pub id: i64,
+    pub name: String,
+    pub description: String,
+    pub kind: AdvantageKind,
+    pub tags: Vec<String>,
+    pub properties: Vec<Field>,
+    pub is_custom: bool,
+    /// FVTT-import provenance. None = hand-authored locally (corebook or
+    /// GM custom). Some = imported from a Foundry world; JSON shape
+    /// described in the migration comment. Promoted to a tagged enum
+    /// when a second source materializes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_attribution: Option<serde_json::Value>,
+}
+```
+
+The `kind` field is placed between `description` and `tags` (matches the SQL column order from the migration). `#[serde(default)]` on `source_attribution` makes deserialization tolerant of pre-migration payloads in tests.
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo check --manifest-path src-tauri/Cargo.toml`
+
+Expected: the build now fails everywhere `Advantage` is constructed without `kind` — this is the safety net. Note the failing locations: `db/advantage.rs` (insert helper, tests), `db/seed.rs` (not yet — seed writes raw SQL), and any tests in `db/modifier.rs` / `db/saved_character.rs` / `tools/character.rs` that construct `Advantage` values directly.
+
+- [ ] **Step 4: Commit (after Task 3 + 4 land — DO NOT commit Task 2 alone)**
+
+Task 2's diff doesn't compile in isolation (struct construction sites break). The implementer subagent should leave the working tree dirty after Task 2 and proceed directly to Tasks 3 and 4. The commit for Task 2 lands as part of Task 3's commit (atomic struct extension + first consumer update).
+
+If using the single-implementer-per-task pattern strictly, dispatch Tasks 2 + 3 to the same implementer with the instruction "land Tasks 2 and 3 as a single atomic commit titled 'Extend Advantage struct + db/advantage.rs for kind/source_attribution'."
+
+---
+
+## Task 3: Update `db/advantage.rs` to read/write the new columns
+
+**Goal:** Thread `kind` and `source_attribution` through every helper in `db/advantage.rs`. Add three new tests: kind round-trip on insert, source-attribution round-trip on insert, and a `list_by_kind` filter helper (no Tauri command — internal helper for Plan C's importer).
+
+**Files:**
+- Modify: `src-tauri/src/db/advantage.rs`
+
+**Anti-scope:** Do NOT add any new `#[tauri::command]` in this task. (Plan C adds `import_advantage_from_world`; nothing in Plan A is FVTT-aware.) Do NOT touch `roll_random_advantage`'s tag-filter logic — kind filtering happens at the Tauri layer in Plan C, not here.
+
+**Depends on:** Task 2
+
+**Invariants cited:** ARCHITECTURE.md §5 (only `db/*` talks to SQLite), §7 (`db/advantage.*` error prefix on `Err` strings).
+
+**Tests required:** YES — 3 new tests minimum (kind round-trip, source-attribution round-trip, `db_list_by_kind` filter). Plus all 11 existing tests must still pass.
+
+- [ ] **Step 1: Update internal helpers**
+
+In `src-tauri/src/db/advantage.rs`:
+
+- Replace `db_list`'s SELECT column list and row-mapping to include `kind, source_attribution`. Parse `kind` via `serde_json::from_str` of a one-element wrapper or just match the string manually (`"merit" => AdvantageKind::Merit`, …).
+- Add new internal helper `db_list_by_kind(pool, kind: AdvantageKind) -> Result<Vec<Advantage>, String>` running `SELECT … FROM advantages WHERE kind = ? ORDER BY is_custom ASC, id ASC`.
+- Extend `db_insert` to take `kind: AdvantageKind` + `source_attribution: Option<&serde_json::Value>` parameters; serialize `source_attribution` via `serde_json::to_string` (or pass `None → SQL NULL`); INSERT 7 columns now.
+- Extend `db_update` similarly (also accept `kind` so the GM can re-tag a custom advantage's kind via the form).
+
+Use these column-string helpers (keep them inline in the file):
+
+```rust
+fn kind_to_str(k: AdvantageKind) -> &'static str {
+    match k {
+        AdvantageKind::Merit      => "merit",
+        AdvantageKind::Flaw       => "flaw",
+        AdvantageKind::Background => "background",
+        AdvantageKind::Boon       => "boon",
+    }
+}
+
+fn str_to_kind(s: &str) -> Result<AdvantageKind, String> {
+    match s {
+        "merit"      => Ok(AdvantageKind::Merit),
+        "flaw"       => Ok(AdvantageKind::Flaw),
+        "background" => Ok(AdvantageKind::Background),
+        "boon"       => Ok(AdvantageKind::Boon),
+        other        => Err(format!("db/advantage: unknown kind: {other}")),
+    }
+}
+```
+
+- [ ] **Step 2: Update Tauri command signatures**
+
+Extend `add_advantage` and `update_advantage` to accept `kind: AdvantageKind` (required, before `tags`). Frontend wrapper signature changes in Task 6.
+
+`list_advantages`, `delete_advantage`, `roll_random_advantage` are unchanged at the Tauri boundary — they only consume the row by id or list-all-then-filter-in-rust.
+
+- [ ] **Step 3: Update the in-memory test schema**
+
+In the `#[cfg(test)] mod tests` block, the `test_pool()` helper currently creates `advantages` without the new columns. Update its CREATE TABLE to mirror the production schema post-migration:
+
+```rust
+async fn test_pool() -> SqlitePool {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    sqlx::query(
+        "CREATE TABLE advantages (
+            id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+            name               TEXT NOT NULL,
+            description        TEXT NOT NULL DEFAULT '',
+            tags_json          TEXT NOT NULL DEFAULT '[]',
+            properties_json    TEXT NOT NULL DEFAULT '[]',
+            is_custom          INTEGER NOT NULL DEFAULT 0,
+            kind               TEXT NOT NULL DEFAULT 'merit'
+                CHECK(kind IN ('merit','flaw','background','boon')),
+            source_attribution TEXT
+        )"
+    ).execute(&pool).await.unwrap();
+    pool
+}
+```
+
+Note: column order matches the post-migration table (ALTER TABLE appends, so `kind` + `source_attribution` are at the end in the real DB; tests should mirror that).
+
+- [ ] **Step 4: Update existing tests for the new `kind` parameter**
+
+Every `db_insert(&pool, "Name", "desc", &tags, &props)` call in tests becomes `db_insert(&pool, "Name", "desc", AdvantageKind::Merit, None, &tags, &props)` (or pick the appropriate kind). The 3 `roll_random_*` tests can keep merits/backgrounds/flaws but explicitly pass the matching `AdvantageKind` value.
+
+- [ ] **Step 5: Add three new tests**
+
+```rust
+#[tokio::test]
+async fn kind_round_trips_through_insert_and_list() {
+    let pool = test_pool().await;
+    db_insert(&pool, "F1", "", AdvantageKind::Flaw, None, &[], &[]).await.unwrap();
+    db_insert(&pool, "B1", "", AdvantageKind::Background, None, &[], &[]).await.unwrap();
+    db_insert(&pool, "M1", "", AdvantageKind::Merit, None, &[], &[]).await.unwrap();
+    let rows = db_list(&pool).await.unwrap();
+    let by_name: std::collections::HashMap<_,_> = rows.iter().map(|r| (r.name.clone(), r.kind)).collect();
+    assert_eq!(by_name["F1"], AdvantageKind::Flaw);
+    assert_eq!(by_name["B1"], AdvantageKind::Background);
+    assert_eq!(by_name["M1"], AdvantageKind::Merit);
+}
+
+#[tokio::test]
+async fn source_attribution_round_trips_through_insert_and_list() {
+    let pool = test_pool().await;
+    let attribution = serde_json::json!({
+        "source": "foundry",
+        "world_title": "Chronicles of Chicago",
+        "imported_at": "2026-05-14T12:00:00Z",
+    });
+    db_insert(&pool, "Imported Merit", "", AdvantageKind::Merit, Some(&attribution), &[], &[]).await.unwrap();
+    db_insert(&pool, "Local Merit",    "", AdvantageKind::Merit, None, &[], &[]).await.unwrap();
+    let rows = db_list(&pool).await.unwrap();
+    let by_name: std::collections::HashMap<_,_> =
+        rows.iter().map(|r| (r.name.clone(), r.source_attribution.clone())).collect();
+    assert_eq!(by_name["Imported Merit"].as_ref().unwrap()["world_title"], "Chronicles of Chicago");
+    assert!(by_name["Local Merit"].is_none());
+}
+
+#[tokio::test]
+async fn list_by_kind_filters_correctly() {
+    let pool = test_pool().await;
+    db_insert(&pool, "F1", "", AdvantageKind::Flaw, None, &[], &[]).await.unwrap();
+    db_insert(&pool, "F2", "", AdvantageKind::Flaw, None, &[], &[]).await.unwrap();
+    db_insert(&pool, "M1", "", AdvantageKind::Merit, None, &[], &[]).await.unwrap();
+    let flaws = db_list_by_kind(&pool, AdvantageKind::Flaw).await.unwrap();
+    assert_eq!(flaws.len(), 2);
+    assert!(flaws.iter().all(|r| r.kind == AdvantageKind::Flaw));
+}
+```
+
+- [ ] **Step 6: Run `cargo test`**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml db::advantage`
+
+Expected: all existing tests pass (with kind=Merit injected at the unused-discriminator sites); 3 new tests pass.
+
+- [ ] **Step 7: Run `./scripts/verify.sh`**
+
+Expected: `cargo check`, `cargo test`, `npm run check`, frontend build all green. `npm run check` may now fail at the TS boundary because `Advantage` has new required fields — Task 6 fixes the TS side; if `verify.sh` fails here, it's expected and Task 6 will resolve it. Move on to Task 4 (also independent of TS).
+
+- [ ] **Step 8: Commit (atomic with Task 2)**
+
+```
+git add src-tauri/src/shared/types.rs src-tauri/src/db/advantage.rs
+git commit -m "$(cat <<'EOF'
+Extend Advantage struct + db/advantage.rs for kind/source_attribution
+
+Adds AdvantageKind enum (merit/flaw/background/boon) and threads it
+through every helper. source_attribution stays a JSON blob (Value) for
+v1; promotion to typed enum deferred until a second source materializes.
+Three new tests cover kind round-trip, source-attribution round-trip,
+and the new internal db_list_by_kind filter helper.
+
+Refs #13 #14 #15.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 4: Update `db/seed.rs` to write `kind` on INSERT
+
+**Goal:** The destructive reseed (ADR 0002) must populate the new `kind` column on every corebook row. Annotate each `SeedRow` with its kind; emit `kind` in the INSERT.
+
+**Files:**
+- Modify: `src-tauri/src/db/seed.rs`
+
+**Anti-scope:** Do NOT change the corebook seed content (names, descriptions, levels). Do NOT touch `seed_dyscrasias` — separate table, untouched by Phase 4.
+
+**Depends on:** Task 2 (`AdvantageKind` enum must exist).
+
+**Invariants cited:** ARCHITECTURE.md §6 ([ADR 0002](docs/adr/0002-destructive-reseed.md) — `is_custom = 0` rows are reseeded on every startup; this invariant is preserved). The new `kind` column is `NOT NULL`, so the INSERT must include it explicitly (the SQL `DEFAULT 'merit'` is a migration safety net for legacy rows; seed must be explicit).
+
+**Tests required:** NO — the migration runtime check in Task 1 already verified seed kinds match expectations. Seed correctness is enforced by Task 1 Step 3's manual verification.
+
+- [ ] **Step 1: Extend `SeedRow` struct**
+
+In `src-tauri/src/db/seed.rs` (around line 120), add a `kind` field:
+
+```rust
+struct SeedRow {
+    name: &'static str,
+    description: &'static str,
+    kind: crate::shared::types::AdvantageKind,
+    tags: &'static [&'static str],
+    level: Option<i64>,
+    level_max: Option<i64>,
+    source: &'static str,
+}
+```
+
+- [ ] **Step 2: Annotate every `SeedRow` literal**
+
+In `fn seed_rows()`, add `kind: AdvantageKind::Merit` (or `Flaw` / `Background`) to each `SeedRow { … }` literal. Cross-check with the existing `tags` array — the kind matches whichever of "Merit" / "Flaw" / "Background" appears there.
+
+Currently in seed (per inspection):
+- Iron Gullet, Eat Food, Bloodhound, Beautiful → `AdvantageKind::Merit`
+- Allies, Contacts, Haven, Resources → `AdvantageKind::Background`
+- Prey Exclusion, Enemy → `AdvantageKind::Flaw`
+- (No Boons in V5 corebook seed.)
+
+The `tags` array keeps its `"Merit"` / `"Background"` / `"Flaw"` string for backward UI compatibility (the existing tag-filter row in AdvantagesManager will keep working until Task 7 replaces it with the kind filter).
+
+Add an import line at the top of the file if it doesn't already pull `AdvantageKind`: `use crate::shared::types::AdvantageKind;`.
+
+- [ ] **Step 3: Update `seed_advantages` to emit `kind`**
+
+Change the INSERT statement and bind list:
+
+```rust
+sqlx::query(
+    "INSERT INTO advantages (name, description, kind, tags_json, properties_json, is_custom)
+     VALUES (?, ?, ?, ?, ?, 0)"
+)
+.bind(row.name)
+.bind(row.description)
+.bind(kind_to_str(row.kind))  // local helper; mirror the one in db/advantage.rs
+.bind(&tags_json)
+.bind(&props_json)
+.execute(pool)
+.await?;
+```
+
+Add the local `kind_to_str` helper at the top of `seed.rs` (duplicating the one in `db/advantage.rs` is acceptable — small private helper, no abstraction wanted per the YAGNI override).
+
+`source_attribution` is omitted from the INSERT — it defaults to NULL, which is correct for corebook rows.
+
+- [ ] **Step 4: Run `cargo check`**
+
+Run: `cargo check --manifest-path src-tauri/Cargo.toml`
+
+Expected: clean.
+
+- [ ] **Step 5: Verify the destructive reseed still works**
+
+Delete the dev DB, run `npm run tauri dev`, exit immediately, then:
+
+```bash
+sqlite3 ~/.local/share/com.hampternt.vtmtools/vtmtools.db \
+  "SELECT kind, COUNT(*) FROM advantages WHERE is_custom = 0 GROUP BY kind;"
+```
+
+Expected:
+- `background  4`
+- `flaw        2`
+- `merit       4`
+
+If counts are off, the seed annotation is wrong — go back to Step 2.
+
+- [ ] **Step 6: Run `./scripts/verify.sh`**
+
+Expected: green (cargo side). TS side may still fail until Task 6 — acceptable; verify cargo passes.
+
+- [ ] **Step 7: Commit**
+
+```
+git add src-tauri/src/db/seed.rs
+git commit -m "$(cat <<'EOF'
+Seed corebook advantages with explicit kind discriminator
+
+Annotates every SeedRow with AdvantageKind; seed_advantages now emits
+the kind column on INSERT. Preserves ADR 0002 destructive reseed
+invariant (is_custom = 0 rows replaced on every startup).
+
+Refs #13 #14 #15.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 5: Audit non-advantage consumers for breakage
+
+**Goal:** Confirm that `db/modifier.rs`, `tools/character.rs`, `db/saved_character.rs`, and `src/lib/saved-characters/diff.ts` don't depend on the now-deprecated tag-based kind discrimination. If any does, surface the gap and fix it in this task. If audit is clean, the task is a no-op commit-wise.
+
+**Files (audit only — modifications conditional):**
+- Inspect: `src-tauri/src/db/modifier.rs::materialize_advantage_modifier` (and its callers)
+- Inspect: `src-tauri/src/tools/character.rs::character_add_advantage` and `character_remove_advantage`
+- Inspect: `src-tauri/src/db/saved_character.rs::db_add_advantage`
+- Inspect: `src/lib/saved-characters/diff.ts` (any reference to advantage tag strings)
+
+**Anti-scope:** Do NOT refactor working code. Only fix if a consumer is genuinely broken by the new struct shape (i.e., constructs `Advantage { … }` directly without `kind` / `source_attribution`).
+
+**Depends on:** Task 3 (`Advantage` struct extension applied)
+
+**Invariants cited:** ARCHITECTURE.md §11 anti-scope discipline.
+
+**Tests required:** NO (audit task)
+
+- [ ] **Step 1: Compile-check the audit**
+
+Run: `cargo check --manifest-path src-tauri/Cargo.toml`
+
+If clean: every consumer reads `Advantage` via serde deserialization or by `id` — no breakage. Skip to Step 4.
+
+If there are compilation errors: each one is a site that constructs `Advantage { … }` literally. For each error, **add `kind: AdvantageKind::Merit, source_attribution: None,` to the literal** (the test sites in modifier.rs/character.rs are test fixtures that construct fake advantage rows — `Merit` is the safe default discriminator for fixture rows).
+
+- [ ] **Step 2: Verify `db/saved_character.rs::db_add_advantage`**
+
+Read `src-tauri/src/db/saved_character.rs` lines ~215-240. The function validates featuretype against `merit/flaw/background/boon` via its own match. **Confirmation:** this function takes featuretype as a parameter (probably from a frontend call), not from a row in `advantages`. No change needed.
+
+- [ ] **Step 3: Verify `diff.ts`**
+
+Read `src/lib/saved-characters/diff.ts`. Search for any reference to `advantage`, `tags`, `merit`, `flaw`, `background`. The diff projection is about character-on-actor specialties/items, not local-library advantages — should be unrelated.
+
+Confirmation: the file `src/lib/saved-characters/diff.ts` is referenced by `src/components/CompareModal.svelte` and does NOT consume `listAdvantages`. No change needed.
+
+- [ ] **Step 4: Run `./scripts/verify.sh`**
+
+Expected: cargo green; TS still failing (Task 6 resolves).
+
+- [ ] **Step 5: Commit IF changes were made**
+
+If Step 1 required edits to test fixtures:
+
+```
+git add -A
+git commit -m "$(cat <<'EOF'
+Update Advantage test fixtures for kind/source_attribution
+
+Test sites that construct Advantage literals receive kind: Merit and
+source_attribution: None defaults. No production behavior change.
+
+Refs #13 #14 #15.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+If no changes were needed: skip the commit, leave a note in the task tracker that audit was clean.
+
+---
+
+## Task 6: Mirror types in `src/types.ts` + extend `src/lib/advantages/api.ts`
+
+**Goal:** Cross the IPC boundary cleanly — TS types match the Rust struct shape post-Task 3; the typed wrappers thread `kind` through `addAdvantage` and `updateAdvantage`. No UI changes yet.
+
+**Files:**
+- Modify: `src/types.ts`
+- Modify: `src/lib/advantages/api.ts`
+
+**Anti-scope:** Do NOT call `invoke(...)` directly anywhere (CLAUDE.md rule). Do NOT touch any `.svelte` component.
+
+**Depends on:** Task 3 (`Advantage` Rust struct + Tauri command signatures extended)
+
+**Invariants cited:** ARCHITECTURE.md §4 (typed frontend API wrappers; components never call `invoke` directly).
+
+**Tests required:** NO (TS-only; `npm run check` is the gate).
+
+- [ ] **Step 1: Mirror `AdvantageKind` in `src/types.ts`**
+
+Add a discriminated string union (matches Rust's `#[serde(rename_all = "snake_case")]`):
+
+```ts
+export type AdvantageKind = 'merit' | 'flaw' | 'background' | 'boon';
+```
+
+- [ ] **Step 2: Extend the `Advantage` interface**
+
+Find the existing `Advantage` interface in `src/types.ts` (it mirrors the Rust struct field-for-field with camelCase). Add the two new fields:
+
+```ts
+export interface Advantage {
+  id: number;
+  name: string;
+  description: string;
+  kind: AdvantageKind;
+  tags: string[];
+  properties: Field[];
+  isCustom: boolean;
+  /**
+   * FVTT-import provenance. undefined = hand-authored locally
+   * (corebook or GM custom). Shape (when defined):
+   *   { source: 'foundry', worldTitle: string, worldId?: string,
+   *     systemVersion?: string, importedAt: string /* ISO-8601 */ }
+   * Stays as a free-form object until a second source materializes.
+   */
+  sourceAttribution?: Record<string, unknown>;
+}
+```
+
+Note: the `serde(rename_all = "camelCase")` on the Rust struct converts `source_attribution → sourceAttribution` automatically. Use `sourceAttribution` on the TS side.
+
+- [ ] **Step 3: Extend `AdvantageInput` and wrappers in `api.ts`**
+
+```ts
+import { invoke } from '@tauri-apps/api/core';
+import type { Advantage, AdvantageKind, Field } from '../../types';
+
+export type AdvantageInput = {
+  name: string;
+  description: string;
+  kind: AdvantageKind;
+  tags: string[];
+  properties: Field[];
+};
+
+export function listAdvantages(): Promise<Advantage[]> {
+  return invoke<Advantage[]>('list_advantages');
+}
+
+export function addAdvantage(input: AdvantageInput): Promise<Advantage> {
+  return invoke<Advantage>('add_advantage', input);
+}
+
+export function updateAdvantage(id: number, input: AdvantageInput): Promise<void> {
+  return invoke<void>('update_advantage', { id, ...input });
+}
+
+export function deleteAdvantage(id: number): Promise<void> {
+  return invoke<void>('delete_advantage', { id });
+}
+
+export function rollRandomAdvantage(tags: string[]): Promise<Advantage | null> {
+  return invoke<Advantage | null>('roll_random_advantage', { tags });
+}
+```
+
+- [ ] **Step 4: Run `npm run check`**
+
+Expected: errors at every `addAdvantage(...)` / `updateAdvantage(...)` call site that doesn't yet pass `kind`. Those are in `AdvantagesManager.svelte` and `AdvantageForm.svelte` (and possibly tests). Task 7 fixes them.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/types.ts src/lib/advantages/api.ts
+git commit -m "$(cat <<'EOF'
+Mirror AdvantageKind + sourceAttribution in TS types and api wrapper
+
+Frontend Advantage interface gains kind (required) and sourceAttribution
+(optional, free-form object). AdvantageInput requires kind for add/update.
+UI consumers update in next task.
+
+Refs #13 #14 #15.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 7: Update `AdvantagesManager.svelte` + `AdvantageForm.svelte`
+
+**Goal:** Render a kind chip on each advantage card; add a kind filter to the existing filter row; the add/edit form gains a required kind selector. NO source-attribution chip yet (Plan C ships that).
+
+**Files:**
+- Modify: `src/tools/AdvantagesManager.svelte`
+- Modify: `src/lib/components/AdvantageForm.svelte`
+- Modify: `src/lib/components/AdvantageCard.svelte` (if kind chip renders inside the card — verify which component owns the per-row chip strip)
+
+**Anti-scope:** Do NOT add a FVTT-source chip or import button. Do NOT change card layout/CSS tokens beyond adding the kind chip — reuse the existing tag-chip styling. Do NOT call `invoke()` directly.
+
+**Depends on:** Task 6
+
+**Invariants cited:** ARCHITECTURE.md §4 (typed wrappers only), §6 (no hardcoded hex; use CSS tokens from `:root` in `+layout.svelte`).
+
+**Tests required:** NO (UI; manual smoke covers it). The verify gate is `npm run check` + `npm run build`.
+
+- [ ] **Step 1: Add a `kind` selector to `AdvantageForm.svelte`**
+
+Open `src/lib/components/AdvantageForm.svelte`. Locate the existing name/description/tags inputs. Add a `kind` selector (HTML `<select>` is sufficient — matches the existing form aesthetic):
+
+- Add `let kind: AdvantageKind = $state(props.initial?.kind ?? 'merit');` near the top of the script block.
+- Add a labeled `<select>` between the name input and the tags input, with options `merit / flaw / background / boon`. Use existing form-row CSS classes.
+- Include `kind` in the `AdvantageInput` payload passed to the parent's save handler.
+
+- [ ] **Step 2: Display a kind chip on each row in `AdvantagesManager.svelte`**
+
+The exact location depends on whether per-row chips render in `AdvantagesManager.svelte` (top-level) or inside `AdvantageCard.svelte`. Read both files first.
+
+If the chip strip lives in `AdvantageCard.svelte`, add the kind chip there with `data-kind={advantage.kind}` for CSS hooks. If it lives at the manager level, add it there.
+
+Chip rendering — reuse the tag-chip pattern, but with a `data-kind` attribute so CSS in the same file can color-code:
+
+```svelte
+<span class="chip kind-chip" data-kind={adv.kind}>{capitalize(adv.kind)}</span>
+```
+
+CSS — add to the existing `<style>` block (or `AdvantageCard.svelte`'s style block):
+
+```css
+.kind-chip[data-kind="merit"]      { background: var(--accent-merit, var(--accent)); }
+.kind-chip[data-kind="flaw"]       { background: var(--accent-flaw, var(--danger)); }
+.kind-chip[data-kind="background"] { background: var(--accent-background, var(--accent-muted)); }
+.kind-chip[data-kind="boon"]       { background: var(--accent-boon, var(--accent-strong)); }
+```
+
+The CSS uses `var(...)` with fallbacks so no token additions are required in `+layout.svelte` for v1; if the GM wants distinct accents per kind later, they're added to `:root` then.
+
+- [ ] **Step 3: Add a kind filter to the existing filter row**
+
+In `AdvantagesManager.svelte`, the existing `activeTags: Set<string>` filter already covers tag-based filtering. Decide between:
+
+- **Option A (recommended, smaller):** Re-derive the `"Merit"` / `"Flaw"` / `"Background"` tags as kind-aware filter chips. Existing rows still carry these tag strings (Task 4 preserved them), so the tag filter implicitly covers kind. Add a small visual treatment so kind-tag chips render distinctly (e.g. `tags-row .kind-tag-chip` styling — match the `data-kind` accent above).
+- **Option B (cleaner but more change):** Replace the tag-filter row with parallel "Kind" + "Tag" rows. New state `activeKinds: Set<AdvantageKind>` + new derived `matchesKind`. More code; cleaner separation. Add `__all__` sentinel matching the existing pattern.
+
+Pick Option A for Plan A; Option B becomes a follow-up if the kind/tag conflation in the UI confuses users.
+
+- [ ] **Step 4: Wire `kind` into Add / Edit dispatches**
+
+Find every call to `addAdvantage({ ... })` and `updateAdvantage(id, { ... })` in `AdvantagesManager.svelte`. Each must now pass `kind`. The form's `kind` state (Task 1) is the source.
+
+- [ ] **Step 5: Run `npm run check` then `npm run build`**
+
+Expected: both green.
+
+- [ ] **Step 6: Manual smoke**
+
+Run `npm run tauri dev`. Open the Advantages tool.
+
+- ✅ Existing rows render with their kind chip (3 merits / 2 flaws / 4 backgrounds visible — corebook seed counts).
+- ✅ Tag filter still works (clicking "Merit" tag filters to merits).
+- ✅ Add Advantage form has a kind selector; defaults to "Merit"; saving a new "Boon" row shows up with the boon chip color.
+- ✅ Edit existing custom row: kind selector preselected; changing kind + saving persists across app restart.
+
+- [ ] **Step 7: Run `./scripts/verify.sh`**
+
+Expected: full green.
+
+- [ ] **Step 8: Commit**
+
+```
+git add src/tools/AdvantagesManager.svelte src/lib/components/AdvantageForm.svelte src/lib/components/AdvantageCard.svelte
+git commit -m "$(cat <<'EOF'
+Render kind chip and kind selector in AdvantagesManager
+
+Each row now shows its kind discriminator visually. Add/Edit form
+requires a kind selection (defaults to Merit). CSS color-coding via
+data-kind attribute with sensible token fallbacks; no hardcoded hex.
+
+Refs #13 #14 #15.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 8: Update `ARCHITECTURE.md` §6 + §9
+
+**Goal:** Document the two new invariants introduced by Plan A: (1) `is_custom` semantics shifted from binary to tri-state (after Plan C lands), and (2) the partitioning rule for adding a library kind.
+
+**Files:**
+- Modify: `ARCHITECTURE.md`
+
+**Anti-scope:** Do NOT update the IPC inventory in §4 (Plan A adds no new commands). Plan B and Plan C will update it when they add their commands.
+
+**Depends on:** Task 7
+
+**Invariants cited:** ARCHITECTURE.md is itself the source of truth; this task amends it.
+
+**Tests required:** NO (docs).
+
+- [ ] **Step 1: Add §6 paragraph on `is_custom` semantics**
+
+In `ARCHITECTURE.md` §6 Invariants, find the existing paragraph about destructive reseed (or add adjacent to it). Add:
+
+> - **`advantages.is_custom` tri-state read.** Pre-Phase-4 the column was binary (0 = corebook reseed-managed, 1 = GM hand-authored). Post-Phase-4 imported FVTT rows are also `is_custom = 1` (so destructive reseed leaves them alone — same survival semantics as hand-authored) BUT they're visually distinguished by a non-null `source_attribution` JSON column. The tri-state is therefore:
+>   - `is_custom = 0` → corebook seed; replaced on every startup (ADR 0002).
+>   - `is_custom = 1 AND source_attribution IS NULL` → GM hand-authored locally; survives reseed; editable in AdvantagesManager.
+>   - `is_custom = 1 AND source_attribution IS NOT NULL` → FVTT-imported; survives reseed; UI shows source chip with world title.
+>
+>   UI filters and reaper helpers MUST treat the latter two as semantically distinct "local" vs. "imported" states despite identical persistence flags.
+
+- [ ] **Step 2: Add §9 paragraph on "Add a library kind"**
+
+In `ARCHITECTURE.md` §9 Extensibility seams (after "Add a VTT bridge source" and before "Add a card-shaped surface"), insert:
+
+> - **Add a library kind.** Phase 4 partitioning rule: **same row shape → polymorphic table with a `kind` discriminator column; different row shape → its own table.** The four featuretype variants (`merit`, `flaw`, `background`, `boon`) share an identical row shape AND an identical Foundry push contract (`actor.create_feature` accepts featuretype as a payload field — foundry helper roadmap §5), so they share the polymorphic `advantages` table. Dyscrasias have a distinct shape (`resonance_type`, `bonus`) and their own table. Disciplines (when they land) will have yet another distinct shape (power tree, Amalgam refs, level-gated powers) and their own table. To add a new variant that shares the advantage row shape: extend `AdvantageKind` enum in `shared/types.rs`, update the SQL CHECK constraint via a new migration, annotate any new seed rows, and wire the chip in `AdvantagesManager.svelte`. To add a new variant that does NOT share the row shape: new table + new `db/<kind>.rs` module + new manager tool, following the dyscrasia pattern.
+
+- [ ] **Step 3: Run `./scripts/verify.sh`**
+
+Expected: green.
+
+- [ ] **Step 4: Commit**
+
+```
+git add ARCHITECTURE.md
+git commit -m "$(cat <<'EOF'
+Document is_custom tri-state + library-kind partitioning rule
+
+§6 records the post-Phase-4 semantic shift on advantages.is_custom
+(reseed-managed / local / imported). §9 codifies when a new library
+kind shares the polymorphic table vs gets its own.
+
+Refs #13 #14 #15.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 9: Final verification gate
+
+**Goal:** Confirm Plan A end-to-end before handing off to Plan B / Plan C.
+
+- [ ] **Step 1: Run `./scripts/verify.sh`**
+
+Expected: full green.
+
+- [ ] **Step 2: Smoke-test against a clean dev DB**
+
+Delete the dev DB; `npm run tauri dev`; open Advantages tool; verify:
+
+- 10 corebook rows present (4 merit / 2 flaw / 4 background).
+- Each row shows the correct kind chip.
+- Add a custom Boon → appears with boon-colored chip.
+- Restart app → custom row survives; corebook reseeds (kind preserved on corebook).
+
+- [ ] **Step 3: Update plan checkbox state**
+
+Mark every Task 1–8 step as `[x]` in this file. Commit:
+
+```
+git add docs/superpowers/plans/2026-05-14-library-sync-plan-a-library-schema-foundation.md
+git commit -m "$(cat <<'EOF'
+Mark Plan A tasks complete
+
+Plan A (library schema foundation) shipped. Unblocks Plan B (push) and
+Plan C (pull + attribution + dedup).
+
+Refs #13 #14 #15.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+Plan A is complete. Plan B and Plan C may now dispatch (Plan B in parallel since #13 is independent of Plan C; Plan C is sequential after Plan B because its UI for source-attribution depends on Plan B's item subscription enabling the pull path).

--- a/docs/superpowers/plans/2026-05-14-library-sync-plan-b-push-and-item-subscription.md
+++ b/docs/superpowers/plans/2026-05-14-library-sync-plan-b-push-and-item-subscription.md
@@ -1,0 +1,1674 @@
+# Library Sync — Plan B: Push + item subscription
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Project lean-execution override (CLAUDE.md):** dispatch ONE implementer subagent per task with full task text + scene-setting context, run `./scripts/verify.sh` after the implementer commits, then move on. After ALL Plans (A + B + C) tasks are committed, run a SINGLE `code-review:code-review` against the full Phase 4 branch diff.
+>
+> **TDD-on-demand override (CLAUDE.md):** subagents do NOT auto-invoke `superpowers:test-driven-development`. Each task below explicitly states whether tests are required.
+
+**Goal:** Two independent pieces of Foundry-bridge work that ship together because they share the same module version bump:
+- **#27 — Item subscription enablement.** Extend the `bridge.subscribe` protocol to accept `collection: "item"`. The Foundry module hooks `createItem`/`updateItem`/`deleteItem` for **world-level** Item docs only (embedded actor items already arrive via the existing actor enrichment path). Desktop adds `FoundryInbound::Items` snapshot variant + per-item upsert/delete variants + `bridge://foundry/items-updated` event.
+- **#13 — Push library entry → Foundry world.** New `world.*` umbrella (one helper: `world.create_item`) and a Tauri command `push_advantage_to_world(id: i64)` that loads the local advantage row by id, maps `kind → featuretype`, and pushes a new world-level Item doc to the active Foundry world. Composes Plan A's `kind` column directly. Push button on each AdvantagesManager row gated on Foundry connectivity.
+
+**Architecture:** Two umbrellas added at once because they share a single module version bump (0.6.0 — additive). The `item.*` subscription is purely **inbound**: the desktop sends `bridge.subscribe { collection: "item" }`, the module attaches Foundry hooks and pushes initial snapshot + future deltas. The `world.*` umbrella is purely **outbound**: the desktop sends `world.create_item`, the module calls `Item.create(...)` at world level. No interaction between the two — they're in the same plan only because they ship together to keep the bridge protocol consistent.
+
+**World-level vs. embedded distinction:** Foundry items have a `parent` property — `null` for world-level Item docs, set to an Actor for embedded items. The new subscriber filters `Hooks.on("createItem", item => { if (item.parent === null) push(...) })` so world-level items are reported once via the new path, never double-counted with the existing actor-enrichment path.
+
+**Tech Stack:** Rust (`sqlx`, `serde`, `serde_json`, `tauri`, `tokio`), JavaScript (Foundry module ES module — no transpilation).
+
+**Spec:** `docs/superpowers/specs/2026-04-30-character-tooling-roadmap.md` §5 Phase 4 (sketch) + architect-advisor recommendation. Source sketches in GitHub issues #27 and #13.
+
+**Architecture reference:** `ARCHITECTURE.md` §4 (Bridge WebSocket protocol — new inbound variants, new event), §4 (Tauri IPC — adds `push_advantage_to_world` command), §5 (only `bridge/*` talks to WebSocket), §7 (error envelope routing — already shipped in Plan 0; Plan B's outbound errors flow through it), §9 ("Add a Tauri command" seam + bridge subscription pattern).
+
+**Depends on:** Plan A (uses `Advantage.kind` to map → featuretype; uses `AdvantageKind` enum). Bridge protocol consolidation (Plan 0) has already shipped — `bridge.subscribe` envelope, `subscribers` registry, and the Hello extension are all in place.
+
+**Unblocks:** Plan C (pull-from-world consumes the items snapshot delivered by #27's subscription).
+
+**Issues closed:** #13, #27. (#14, #15, #16 remain — Plan C.)
+
+---
+
+## File structure
+
+### New files
+- `src-tauri/src/bridge/foundry/actions/world.rs` — `build_create_world_item(name, featuretype, description, points) -> Result<Value, String>` builder; module-prefixed errors per ARCH §7. The `world.*` umbrella is reserved here even though only one helper ships in this milestone — future world-level helpers will register here without churning the umbrella convention.
+- `src-tauri/src/tools/library_push.rs` — `push_advantage_to_world(id: i64)` Tauri command. Loads the advantage by id; maps `kind` → featuretype string; composes `actions::world::build_create_world_item(...)`; routes via `bridge::commands::send_to_source_inner(state, SourceKind::Foundry, text)`. No-op (returns Ok) if Foundry not connected — same semantics as `bridge_set_attribute` per `send_to_source_inner` impl.
+- `vtmtools-bridge/scripts/foundry-actions/world.js` — handler `createWorldItem(msg)` that calls `Item.create({ type: "feature", name, system: { featuretype, description, points } })` at world level. No `wireExecutor` wrapper (no `actor_id` resolution needed — world-level).
+- `vtmtools-bridge/scripts/foundry-actions/item.js` — `itemsSubscriber.attach(socket) / .detach()` following the `actorsSubscriber` template. Pushes initial snapshot from `game.items.contents` (world-level only). Hooks `createItem`/`updateItem`/`deleteItem`; each hook filters `if (item.parent !== null) return;` to keep embedded-on-actor items out.
+- `src/lib/library/api.ts` — typed wrapper `pushAdvantageToWorld(id: number): Promise<void>` for the new Tauri command. (Library namespace established here so Plan C extends it with `importAdvantagesFromWorld`.)
+
+### Modified files
+- `src-tauri/src/bridge/foundry/types.rs` — add `FoundryInbound::Items { items: Vec<FoundryWorldItem> }`, `FoundryInbound::WorldItemUpsert { item: FoundryWorldItem }`, `FoundryInbound::WorldItemDeleted { item_id: String }`; add `FoundryWorldItem` struct (id, name, type, featuretype: Option, system: Value).
+- `src-tauri/src/bridge/types.rs` — add `CanonicalWorldItem { source: SourceKind, id, name, kind: String, featuretype: Option<String>, system: Value }` (canonical source-agnostic shape; `system` stays Value to keep the bridge a dumb pipe).
+- `src-tauri/src/bridge/source.rs` — extend `InboundEvent` enum with `WorldItemsSnapshot { source, items }`, `WorldItemUpsert { source, item }`, `WorldItemDeleted { source, item_id }` variants.
+- `src-tauri/src/bridge/foundry/mod.rs::handle_inbound` — match arms for the three new `FoundryInbound` variants → produce the corresponding `InboundEvent`s with `source = SourceKind::Foundry`.
+- `src-tauri/src/bridge/foundry/translate.rs` (or new helper) — `to_canonical_world_item(item: &FoundryWorldItem) -> CanonicalWorldItem` (minimal translation; `kind` derived from `item.type`, `featuretype` lifted from `item.system.featuretype` if present).
+- `src-tauri/src/bridge/mod.rs::accept_loop` — three new arms in the event-routing match (snapshot / upsert / delete). All three emit `bridge://foundry/items-updated` with the full snapshot from a new `BridgeState.world_items: HashMap<SourceKind, HashMap<String, CanonicalWorldItem>>` cache. Pattern mirrors `bridge://characters-updated` (snapshot replaces, upsert inserts, delete evicts; emit full snapshot each time).
+- `src-tauri/src/bridge/mod.rs::BridgeState` — add `world_items: tokio::sync::Mutex<HashMap<SourceKind, HashMap<String, CanonicalWorldItem>>>`.
+- `src-tauri/src/bridge/commands.rs` — add `bridge_get_world_items(source: SourceKind) -> Vec<CanonicalWorldItem>` for frontend initial-load (mirrors `bridge_get_characters`).
+- `src-tauri/src/bridge/foundry/actions/mod.rs` — add `pub mod world;`.
+- `src-tauri/src/lib.rs` — register `push_advantage_to_world` and `bridge_get_world_items` in `invoke_handler!`.
+- `src-tauri/src/tools/mod.rs` — `pub mod library_push;`.
+- `vtmtools-bridge/scripts/foundry-actions/index.js` — import + spread `worldHandlers` from `./world.js`.
+- `vtmtools-bridge/scripts/foundry-actions/bridge.js` — register `item: itemsSubscriber` in the `subscribers` map.
+- `vtmtools-bridge/module.json` — version 0.5.0 → 0.6.0 (additive).
+- `src/store/bridge.svelte.ts` — add `worldItems: Record<SourceKind, CanonicalWorldItem[]>` reactive state; subscribe to `bridge://foundry/items-updated` and hydrate from `bridge_get_world_items` on mount. (Plan C consumes this.)
+- `src/types.ts` — mirror `CanonicalWorldItem`.
+- `src/tools/AdvantagesManager.svelte` — add a "Push to world" button per row, visible only when Foundry connection is active (consume `bridgeStatus.foundry` from `src/store/bridge.svelte.ts`). On click, call `pushAdvantageToWorld(id)`; toast on error.
+- `ARCHITECTURE.md` §4 — append `push_advantage_to_world` to `tools/library_push.rs` IPC entry; append `bridge_get_world_items` to `bridge/commands.rs` entry; bump command total 63 → 65; add `bridge://foundry/items-updated` to the events table; add `world.*` umbrella + `item` subscription collection mentions to the Bridge WebSocket protocol section.
+
+### Files explicitly NOT touched
+- `src-tauri/src/db/advantage.rs` — Plan A territory (frozen post-Plan-A).
+- `src-tauri/src/db/dyscrasia.rs` — Plan B does NOT push dyscrasias to the world. The spec sketch said "merit/dyscrasia → Foundry world" but `actor.create_feature` operates on actors, not the world; pushing a dyscrasia-as-world-item conflates merit semantics with dyscrasia semantics. **Anti-scope: dyscrasia push to world remains out of scope.** If the GM wants a dyscrasia in the world library, they create it as a custom merit via `AdvantagesManager.svelte → kind: merit`.
+- Plan A frozen files (Advantage struct, migration).
+- Plan C frozen files (`src/lib/library/api.ts::importAdvantagesFromWorld`, dedup logic, source-attribution chip rendering).
+
+---
+
+## Task overview
+
+| # | Task | Depends on | Tests |
+|---|---|---|---|
+| 1 | Add `FoundryWorldItem` + 3 new `FoundryInbound` variants in `bridge/foundry/types.rs` | none | YES (deserialize round-trip for each variant) |
+| 2 | Add `CanonicalWorldItem` in `bridge/types.rs` + mirror in `src/types.ts` | 1 | NO (struct definition) |
+| 3 | Add `InboundEvent` variants in `bridge/source.rs` + `translate.rs::to_canonical_world_item` | 1, 2 | YES (1 test for translate) |
+| 4 | Wire `FoundryInbound` → `InboundEvent` arms in `bridge/foundry/mod.rs::handle_inbound` | 3 | YES (3 tests, one per variant) |
+| 5 | Extend `BridgeState` with `world_items` cache + route `InboundEvent` arms in `bridge/mod.rs` | 4 | NO (covered by manual smoke + cargo build) |
+| 6 | New JS `vtmtools-bridge/scripts/foundry-actions/item.js` with `itemsSubscriber` (world-level filter) + register `item` in `bridge.js` subscribers | none (JS-only) | NO (manual smoke against live Foundry world) |
+| 7 | New JS `vtmtools-bridge/scripts/foundry-actions/world.js` with `createWorldItem` handler + register in `index.js` | none (JS-only) | NO (manual smoke against live Foundry world) |
+| 8 | Bump `module.json` 0.5.0 → 0.6.0 | 6, 7 | NO |
+| 9 | New Rust `bridge/foundry/actions/world.rs` with `build_create_world_item` builder | none (Rust-only, parallel with 6/7/8) | YES (envelope shape + invalid featuretype rejection) |
+| 10 | New Rust `tools/library_push.rs` with `push_advantage_to_world` Tauri command | 9 + Plan A | YES (1 happy-path test against in-memory pool + faked outbound channel) |
+| 11 | Register `push_advantage_to_world` + `bridge_get_world_items` in `lib.rs` | 10 + (new `bridge_get_world_items` from Task 5) | NO |
+| 12 | Frontend typed wrapper `src/lib/library/api.ts::pushAdvantageToWorld` | 11 | NO |
+| 13 | `src/store/bridge.svelte.ts` reactive `worldItems` state + event subscription | 5 | NO |
+| 14 | AdvantagesManager "Push to world" button | 12, 13 | NO (manual smoke) |
+| 15 | ARCHITECTURE.md §4 updates | 14 | NO |
+| 16 | Final verification gate (incl. live-Foundry E2E smoke) | all | runs `./scripts/verify.sh` + manual E2E |
+
+Tasks 1, 6, 7, 9 are independent (Rust types / JS subscriber / JS handler / Rust builder) and can dispatch in parallel after this plan begins. Tasks 2–5 thread the Rust inbound side sequentially. Tasks 10–14 thread the push outbound side sequentially.
+
+---
+
+## Task 1: Add `FoundryWorldItem` + 3 new `FoundryInbound` variants
+
+**Goal:** Extend the typed inbound wire definitions to accept world-level item snapshots / upserts / deletes. Provides Rust-side compile-time guarantees that JS-side payload shapes are honored.
+
+**Files:**
+- Modify: `src-tauri/src/bridge/foundry/types.rs`
+
+**Anti-scope:** Do NOT modify the existing `FoundryActor::items` field (embedded actor items continue to flow through that). Do NOT add any wire variant beyond the three named here.
+
+**Depends on:** none
+
+**Invariants cited:** ARCHITECTURE.md §4 (Bridge WebSocket protocol — typed inbound). Wire-protocol decision A from foundry helper roadmap §3 (typed-per-helper).
+
+**Tests required:** YES — one deserialize-round-trip test per variant (3 tests).
+
+- [ ] **Step 1: Add `FoundryWorldItem` struct**
+
+In `src-tauri/src/bridge/foundry/types.rs`, after the existing `FoundryActor` struct (around line 92), add:
+
+```rust
+/// World-level Item document. Distinct from embedded-on-actor items —
+/// those arrive via `FoundryActor::items` and stay scoped to their
+/// parent actor. World-level items have no parent (Foundry's
+/// `item.parent === null`); the module's `item` subscriber filters
+/// for them explicitly so this struct never carries an actor_id.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FoundryWorldItem {
+    /// Foundry document _id.
+    pub id: String,
+    pub name: String,
+    /// Foundry Item type ("feature", "speciality", "power", etc.).
+    #[serde(rename = "type")]
+    pub item_type: String,
+    /// system.featuretype when item.type == "feature" (merit/flaw/
+    /// background/boon). None for non-feature items.
+    #[serde(default)]
+    pub featuretype: Option<String>,
+    /// Raw `item.system` blob — opaque to Rust; Plan C's importer picks
+    /// fields (description, points, level) as needed.
+    #[serde(default)]
+    pub system: serde_json::Value,
+}
+```
+
+- [ ] **Step 2: Extend `FoundryInbound` enum**
+
+In the existing `pub enum FoundryInbound` block (lines 11-48), add three new variants:
+
+```rust
+    /// World-level item snapshot — pushed by the module on first
+    /// subscribe to `collection: "item"`. Replaces the entire cached
+    /// items slice for this source.
+    Items {
+        items: Vec<FoundryWorldItem>,
+    },
+
+    /// One world-level item was created or updated.
+    /// Triggered by the module's createItem / updateItem hooks
+    /// (filtered to parent === null).
+    WorldItemUpsert {
+        item: FoundryWorldItem,
+    },
+
+    /// One world-level item was deleted.
+    /// Triggered by the module's deleteItem hook (parent === null filter).
+    WorldItemDeleted {
+        item_id: String,
+    },
+```
+
+Note: the existing `ItemDeleted { actor_id, item_id }` variant stays — it's actor-scoped and serves modifier reaping (a different concern). The new `WorldItemDeleted` is world-scoped (no actor_id).
+
+- [ ] **Step 3: Add deserialize tests**
+
+In the existing `#[cfg(test)] mod tests` block (or add one if absent — verify file structure first), add:
+
+```rust
+#[test]
+fn items_snapshot_deserializes() {
+    let wire = r#"{
+        "type": "items",
+        "items": [
+            { "id": "i1", "name": "Iron Gullet", "type": "feature",
+              "featuretype": "merit", "system": { "description": "..." } }
+        ]
+    }"#;
+    let parsed: FoundryInbound = serde_json::from_str(wire).expect("parses");
+    match parsed {
+        FoundryInbound::Items { items } => {
+            assert_eq!(items.len(), 1);
+            assert_eq!(items[0].name, "Iron Gullet");
+            assert_eq!(items[0].featuretype.as_deref(), Some("merit"));
+        }
+        other => panic!("expected Items, got {other:?}"),
+    }
+}
+
+#[test]
+fn world_item_upsert_deserializes() {
+    let wire = r#"{
+        "type": "world_item_upsert",
+        "item": { "id": "i7", "name": "Bloodhound", "type": "feature",
+                  "featuretype": "merit", "system": {} }
+    }"#;
+    let parsed: FoundryInbound = serde_json::from_str(wire).expect("parses");
+    match parsed {
+        FoundryInbound::WorldItemUpsert { item } => {
+            assert_eq!(item.id, "i7");
+        }
+        other => panic!("expected WorldItemUpsert, got {other:?}"),
+    }
+}
+
+#[test]
+fn world_item_deleted_deserializes() {
+    let wire = r#"{ "type": "world_item_deleted", "item_id": "i99" }"#;
+    let parsed: FoundryInbound = serde_json::from_str(wire).expect("parses");
+    match parsed {
+        FoundryInbound::WorldItemDeleted { item_id } => {
+            assert_eq!(item_id, "i99");
+        }
+        other => panic!("expected WorldItemDeleted, got {other:?}"),
+    }
+}
+```
+
+Wire `type` strings come from `#[serde(tag = "type", rename_all = "snake_case")]` on the enum. The variant names map: `Items → "items"`, `WorldItemUpsert → "world_item_upsert"`, `WorldItemDeleted → "world_item_deleted"`. The JS-side payload must emit these exact strings (Task 6).
+
+- [ ] **Step 4: Run `cargo test`**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml bridge::foundry::types`
+
+Expected: 3 new tests pass; no regressions.
+
+- [ ] **Step 5: Run `./scripts/verify.sh`**
+
+Expected: cargo green; downstream code (`bridge/foundry/mod.rs::handle_inbound`) may not yet handle the new variants — that compiles fine as long as `match` is non-exhaustive over `FoundryInbound`. **Verify:** current `mod.rs::handle_inbound` uses an exhaustive match over `FoundryInbound`, so this step WILL fail at cargo check. That's expected — Task 4 fixes it. If verify.sh fails here at `bridge/foundry/mod.rs::handle_inbound`, commit Task 1 with the failure pinned to Task 4, OR roll Tasks 1+4 into the same commit. **Recommended:** dispatch Tasks 1+4 to the same implementer as a single atomic commit since they share an exhaustiveness invariant.
+
+- [ ] **Step 6: Commit (joint with Task 4 — defer)**
+
+Hold this commit until Task 4 lands; the joint commit is at Task 4 Step 5.
+
+---
+
+## Task 2: Add `CanonicalWorldItem` + mirror in `src/types.ts`
+
+**Goal:** Source-agnostic canonical shape for world items. Stays minimal — `system` remains a JSON Value so the bridge stays a dumb pipe per the architect anti-recommendation.
+
+**Files:**
+- Modify: `src-tauri/src/bridge/types.rs`
+- Modify: `src/types.ts`
+
+**Anti-scope:** Do NOT typedef the contents of `system` (it varies by item.type). Do NOT add Roll20-specific fields — `CanonicalWorldItem` is Foundry-only in practice for v1; the `source: SourceKind` field is for forward-compat only.
+
+**Depends on:** Task 1
+
+**Invariants cited:** ARCHITECTURE.md §3 (`bridge/types.rs` holds canonical shapes); §5 (bridge stays a translation layer).
+
+**Tests required:** NO
+
+- [ ] **Step 1: Add `CanonicalWorldItem` struct**
+
+In `src-tauri/src/bridge/types.rs`, after `CanonicalCharacter` (or wherever canonical types live; verify file structure), add:
+
+```rust
+/// Source-agnostic shape for a world-level (compendium-style) Item doc.
+/// Foundry is the only producer in v1; Roll20 has no analog. The shape
+/// is intentionally minimal — `system` stays as `serde_json::Value` so
+/// the bridge stays a dumb pipe. Consumers (Plan C importer) read
+/// per-kind fields from `system` directly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CanonicalWorldItem {
+    pub source: SourceKind,
+    /// Foundry document _id (or other source's stable id).
+    pub id: String,
+    pub name: String,
+    /// Foundry Item type — e.g. "feature", "speciality", "power".
+    pub kind: String,
+    /// system.featuretype when kind == "feature" — one of
+    /// {"merit","flaw","background","boon"} for the cases Plan B's
+    /// push and Plan C's pull both care about. None otherwise.
+    pub featuretype: Option<String>,
+    pub system: serde_json::Value,
+}
+```
+
+Note: the `kind` field here is the Foundry **Item type** ("feature" / "speciality" / "power"), NOT the `AdvantageKind` enum from Plan A (which is the featuretype sub-discriminator for `kind = "feature"` items). They're related but distinct. Plan C's importer maps `(kind == "feature", featuretype) → AdvantageKind`.
+
+- [ ] **Step 2: Mirror in `src/types.ts`**
+
+Add to `src/types.ts` (camelCase, matching serde):
+
+```ts
+export interface CanonicalWorldItem {
+  source: SourceKind;
+  id: string;
+  name: string;
+  /** Foundry Item type — "feature", "speciality", "power", … */
+  kind: string;
+  /** system.featuretype for feature-typed items; one of
+   *  'merit' | 'flaw' | 'background' | 'boon' in practice. */
+  featuretype?: string;
+  /** Raw item.system blob — opaque on the TS side; Plan C
+   *  reads specific fields per Foundry Item.type. */
+  system: Record<string, unknown>;
+}
+```
+
+- [ ] **Step 3: Run `./scripts/verify.sh`**
+
+Expected: green on the cargo + TS sides; nothing consumes the new type yet.
+
+- [ ] **Step 4: Commit**
+
+```
+git add src-tauri/src/bridge/types.rs src/types.ts
+git commit -m "$(cat <<'EOF'
+Add CanonicalWorldItem (source-agnostic world-level item shape)
+
+Mirrors the post-Plan-B inbound wire variants. system stays a Value
+on Rust / Record<string, unknown> on TS — bridge layer remains a dumb
+pipe; per-kind decoding happens at consumer (Plan C importer).
+
+Refs #27 #14.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 3: Add `InboundEvent` variants + `translate.rs::to_canonical_world_item`
+
+**Goal:** Bridge-internal event variants for the three world-item flows, plus the Foundry-side translator.
+
+**Files:**
+- Modify: `src-tauri/src/bridge/source.rs` (extend `InboundEvent` enum)
+- Modify: `src-tauri/src/bridge/foundry/translate.rs` (new helper)
+
+**Anti-scope:** Do NOT make `to_canonical_world_item` look up actor context — world items are parent-less by construction. Do NOT add a "snapshot replace" / "delta apply" distinction at the InboundEvent level — three variants is enough.
+
+**Depends on:** Tasks 1, 2
+
+**Invariants cited:** ARCH §4 (InboundEvent enum is the bridge-internal protocol between handle_inbound and accept_loop).
+
+**Tests required:** YES — 1 test for `to_canonical_world_item`.
+
+- [ ] **Step 1: Extend `InboundEvent`**
+
+In `src-tauri/src/bridge/source.rs`, add to the existing `InboundEvent` enum:
+
+```rust
+    /// Source pushed a full world-level item snapshot. The bridge cache
+    /// replaces this source's world-items slice — every entry whose
+    /// `source` matches is dropped, then `items` are inserted. Empty
+    /// `items` is legal and means "this source now has zero
+    /// world-level items".
+    WorldItemsSnapshot {
+        source: crate::bridge::types::SourceKind,
+        items: Vec<crate::bridge::types::CanonicalWorldItem>,
+    },
+    /// One world-level item was added or changed. The bridge cache
+    /// inserts or overwrites a single entry keyed by `(source, id)`.
+    WorldItemUpsert {
+        source: crate::bridge::types::SourceKind,
+        item: crate::bridge::types::CanonicalWorldItem,
+    },
+    /// One world-level item was removed. The bridge cache evicts the
+    /// entry keyed by `(source, id)`.
+    WorldItemDeleted {
+        source: crate::bridge::types::SourceKind,
+        item_id: String,
+    },
+```
+
+- [ ] **Step 2: Add `to_canonical_world_item` in `translate.rs`**
+
+In `src-tauri/src/bridge/foundry/translate.rs`, add (or add a new module if translate.rs is actor-only; check the file's current structure first):
+
+```rust
+pub fn to_canonical_world_item(
+    item: &crate::bridge::foundry::types::FoundryWorldItem,
+) -> crate::bridge::types::CanonicalWorldItem {
+    crate::bridge::types::CanonicalWorldItem {
+        source: crate::bridge::types::SourceKind::Foundry,
+        id: item.id.clone(),
+        name: item.name.clone(),
+        kind: item.item_type.clone(),
+        featuretype: item.featuretype.clone(),
+        system: item.system.clone(),
+    }
+}
+```
+
+- [ ] **Step 3: Add a test for the translator**
+
+In `translate.rs`'s `#[cfg(test)] mod tests` block (or add one):
+
+```rust
+#[test]
+fn translate_world_item_preserves_featuretype() {
+    let wire = crate::bridge::foundry::types::FoundryWorldItem {
+        id: "i1".into(),
+        name: "Iron Gullet".into(),
+        item_type: "feature".into(),
+        featuretype: Some("merit".into()),
+        system: serde_json::json!({"description": "..."}),
+    };
+    let canonical = to_canonical_world_item(&wire);
+    assert_eq!(canonical.source, crate::bridge::types::SourceKind::Foundry);
+    assert_eq!(canonical.id, "i1");
+    assert_eq!(canonical.name, "Iron Gullet");
+    assert_eq!(canonical.kind, "feature");
+    assert_eq!(canonical.featuretype.as_deref(), Some("merit"));
+}
+```
+
+- [ ] **Step 4: Run `cargo test` (target translate + source modules)**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml bridge::`
+
+Expected: existing tests still pass; new test passes.
+
+- [ ] **Step 5: Commit (atomic with Task 4 — defer)**
+
+Hold this commit until Task 4; combined commit at Task 4 Step 5.
+
+---
+
+## Task 4: Wire `FoundryInbound` → `InboundEvent` in `handle_inbound`
+
+**Goal:** Complete the inbound translation pipeline so the bridge accept loop can route world-item events.
+
+**Files:**
+- Modify: `src-tauri/src/bridge/foundry/mod.rs::handle_inbound`
+
+**Anti-scope:** Do NOT add new state to `FoundrySource` — it stays stateless per ADR 0006. Do NOT emit Tauri events directly from `handle_inbound` — emission happens in `accept_loop` (Task 5).
+
+**Depends on:** Tasks 1, 2, 3
+
+**Invariants cited:** ARCH §5 (BridgeSource impls are stateless; state lives in BridgeState). ADR 0006.
+
+**Tests required:** YES — 3 tests (one per new variant), pattern matches the existing `actor_deleted_inbound_produces_character_removed_event` test.
+
+- [ ] **Step 1: Add three arms to `handle_inbound`**
+
+In the `match parsed` block of `src-tauri/src/bridge/foundry/mod.rs::handle_inbound`, after the existing `FoundryInbound::ItemDeleted` arm, add:
+
+```rust
+            FoundryInbound::Items { items } => {
+                let canonical: Vec<_> = items.iter().map(translate::to_canonical_world_item).collect();
+                Ok(vec![InboundEvent::WorldItemsSnapshot {
+                    source: crate::bridge::types::SourceKind::Foundry,
+                    items: canonical,
+                }])
+            }
+            FoundryInbound::WorldItemUpsert { item } => {
+                Ok(vec![InboundEvent::WorldItemUpsert {
+                    source: crate::bridge::types::SourceKind::Foundry,
+                    item: translate::to_canonical_world_item(&item),
+                }])
+            }
+            FoundryInbound::WorldItemDeleted { item_id } => {
+                Ok(vec![InboundEvent::WorldItemDeleted {
+                    source: crate::bridge::types::SourceKind::Foundry,
+                    item_id,
+                }])
+            }
+```
+
+- [ ] **Step 2: Add three tests**
+
+In the existing `#[cfg(test)] mod tests` block of `bridge/foundry/mod.rs`:
+
+```rust
+#[tokio::test]
+async fn items_snapshot_produces_world_items_snapshot_event() {
+    let source = FoundrySource;
+    let msg = serde_json::json!({
+        "type": "items",
+        "items": [
+            { "id": "i1", "name": "Iron Gullet", "type": "feature",
+              "featuretype": "merit", "system": {} }
+        ]
+    });
+    let events = source.handle_inbound(msg).await.expect("handles");
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        InboundEvent::WorldItemsSnapshot { source: src, items } => {
+            assert_eq!(*src, SourceKind::Foundry);
+            assert_eq!(items.len(), 1);
+            assert_eq!(items[0].name, "Iron Gullet");
+        }
+        other => panic!("expected WorldItemsSnapshot, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn world_item_upsert_produces_event() {
+    let source = FoundrySource;
+    let msg = serde_json::json!({
+        "type": "world_item_upsert",
+        "item": { "id": "i7", "name": "Bloodhound", "type": "feature",
+                  "featuretype": "merit", "system": {} }
+    });
+    let events = source.handle_inbound(msg).await.expect("handles");
+    assert_eq!(events.len(), 1);
+    assert!(matches!(events[0], InboundEvent::WorldItemUpsert { .. }));
+}
+
+#[tokio::test]
+async fn world_item_deleted_produces_event() {
+    let source = FoundrySource;
+    let msg = serde_json::json!({ "type": "world_item_deleted", "item_id": "i99" });
+    let events = source.handle_inbound(msg).await.expect("handles");
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        InboundEvent::WorldItemDeleted { source: src, item_id } => {
+            assert_eq!(*src, SourceKind::Foundry);
+            assert_eq!(item_id, "i99");
+        }
+        other => panic!("expected WorldItemDeleted, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 3: Run `./scripts/verify.sh`**
+
+Expected: cargo green. `bridge/mod.rs::accept_loop` may now warn about unhandled `InboundEvent::WorldItem*` variants in the match — Task 5 resolves. If the match is currently exhaustive, the build fails; add `WorldItem* => continue,` placeholders inline as TODOs that Task 5 replaces. **Recommended:** ship Tasks 1+3+4+5 as one implementer commit since they share the inbound-pipeline exhaustiveness invariant.
+
+- [ ] **Step 4: Verify state of dependent files**
+
+Confirm `bridge/mod.rs::accept_loop` has been pre-prepared (Task 5) OR has placeholder arms. If neither, this task's commit will leave the working tree non-buildable. Coordinate via the joint Task 5 commit.
+
+- [ ] **Step 5: Joint commit (Tasks 1, 3, 4 + minimal Task 5 stub)**
+
+```
+git add src-tauri/src/bridge/foundry/types.rs \
+        src-tauri/src/bridge/source.rs \
+        src-tauri/src/bridge/foundry/translate.rs \
+        src-tauri/src/bridge/foundry/mod.rs
+git commit -m "$(cat <<'EOF'
+Add inbound world-item wire variants + translation pipeline
+
+Three new FoundryInbound variants (Items, WorldItemUpsert,
+WorldItemDeleted) for the bridge.subscribe { collection: "item" }
+protocol. Source-agnostic CanonicalWorldItem; Foundry translator;
+handle_inbound dispatch + 6 round-trip tests.
+
+bridge/mod.rs::accept_loop event arms ship in the next commit
+(Task 5 stub adds placeholders pinned to a follow-up).
+
+Refs #27.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+If Task 5 stubs are added as part of this commit, drop the trailing paragraph from the message and consolidate the message to cover Task 5 too.
+
+---
+
+## Task 5: Extend `BridgeState` with `world_items` cache + route arms in `accept_loop`
+
+**Goal:** Persist world-item state in `BridgeState`; emit `bridge://foundry/items-updated` after each snapshot / upsert / delete; add `bridge_get_world_items` Tauri command for frontend initial-load.
+
+**Files:**
+- Modify: `src-tauri/src/bridge/mod.rs` (BridgeState struct + accept_loop event-routing match)
+- Modify: `src-tauri/src/bridge/commands.rs` (new command `bridge_get_world_items`)
+
+**Anti-scope:** Do NOT emit per-item events to the frontend — emit the full snapshot each time, mirroring `bridge://characters-updated`. The frontend reactive layer can derive deltas if needed; the bridge stays simple.
+
+**Depends on:** Tasks 3, 4 (InboundEvent variants exist)
+
+**Invariants cited:** ARCH §3 (BridgeState holds the merged cache); §4 (events deliver full snapshots).
+
+**Tests required:** NO — covered by manual smoke (Task 16) plus cargo build (the new Tauri command's compile shape is the gate).
+
+- [ ] **Step 1: Add `world_items` to `BridgeState`**
+
+In `src-tauri/src/bridge/mod.rs`, find the existing `BridgeState` struct. Add a `world_items` field:
+
+```rust
+pub world_items: tokio::sync::Mutex<
+    std::collections::HashMap<
+        crate::bridge::types::SourceKind,
+        std::collections::HashMap<String, crate::bridge::types::CanonicalWorldItem>,
+    >,
+>,
+```
+
+Update `BridgeState::new()` (or the equivalent constructor) to initialize the new field with an empty HashMap.
+
+- [ ] **Step 2: Add three event arms to `accept_loop`**
+
+In `src-tauri/src/bridge/mod.rs::accept_loop`, in the `match event` block (search for `InboundEvent::CharactersSnapshot`), add three new arms after `InboundEvent::ItemDeleted`:
+
+```rust
+InboundEvent::WorldItemsSnapshot { source, items } => {
+    {
+        let mut store = state.world_items.lock().await;
+        let slot = store.entry(source).or_default();
+        slot.clear();
+        for i in &items {
+            slot.insert(i.id.clone(), i.clone());
+        }
+    }
+    let snapshot = collect_world_items_snapshot(&state).await;
+    let _ = handle.emit("bridge://foundry/items-updated", snapshot);
+}
+InboundEvent::WorldItemUpsert { source, item } => {
+    {
+        let mut store = state.world_items.lock().await;
+        store.entry(source).or_default().insert(item.id.clone(), item);
+    }
+    let snapshot = collect_world_items_snapshot(&state).await;
+    let _ = handle.emit("bridge://foundry/items-updated", snapshot);
+}
+InboundEvent::WorldItemDeleted { source, item_id } => {
+    {
+        let mut store = state.world_items.lock().await;
+        if let Some(slot) = store.get_mut(&source) {
+            slot.remove(&item_id);
+        }
+    }
+    let snapshot = collect_world_items_snapshot(&state).await;
+    let _ = handle.emit("bridge://foundry/items-updated", snapshot);
+}
+```
+
+Add the helper `collect_world_items_snapshot` near the bottom of `bridge/mod.rs`:
+
+```rust
+async fn collect_world_items_snapshot(
+    state: &std::sync::Arc<BridgeState>,
+) -> Vec<crate::bridge::types::CanonicalWorldItem> {
+    let store = state.world_items.lock().await;
+    store.values().flat_map(|m| m.values().cloned()).collect()
+}
+```
+
+The emitted payload is a flat `Vec<CanonicalWorldItem>`; the frontend partitions by source if it needs to (the `source` field on each item carries it).
+
+- [ ] **Step 3: Add `bridge_get_world_items` Tauri command**
+
+In `src-tauri/src/bridge/commands.rs`, after `bridge_get_rolls`:
+
+```rust
+/// Returns every world-level item known across every source. Used by
+/// the frontend on initial load; live updates flow through the
+/// `bridge://foundry/items-updated` event.
+#[tauri::command]
+pub async fn bridge_get_world_items(
+    conn: State<'_, BridgeConn>,
+) -> Result<Vec<CanonicalWorldItem>, String> {
+    let store = conn.0.world_items.lock().await;
+    Ok(store.values().flat_map(|m| m.values().cloned()).collect())
+}
+```
+
+(Adjust the `CanonicalWorldItem` import at the top of the file.)
+
+- [ ] **Step 4: Register the new command**
+
+In `src-tauri/src/lib.rs::invoke_handler!`, append `bridge::commands::bridge_get_world_items` to the command list (next to `bridge_get_rolls`).
+
+- [ ] **Step 5: Run `./scripts/verify.sh`**
+
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src-tauri/src/bridge/mod.rs \
+        src-tauri/src/bridge/commands.rs \
+        src-tauri/src/lib.rs
+git commit -m "$(cat <<'EOF'
+Route world-item events through BridgeState + emit
+bridge://foundry/items-updated
+
+Adds BridgeState.world_items cache and three accept_loop arms
+(snapshot / upsert / delete) that emit a full snapshot to the
+frontend on every change. New Tauri command bridge_get_world_items
+for initial-load hydration.
+
+Command surface 63 → 64 (push_advantage_to_world arrives in next
+plan-B commit).
+
+Refs #27.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 6: New JS `foundry-actions/item.js` with `itemsSubscriber` + register `item` collection
+
+**Goal:** The Foundry-side half of #27. New ES module exporting `itemsSubscriber.attach(socket) / .detach()` following the `actorsSubscriber` template. Hooks `createItem`/`updateItem`/`deleteItem` filtered to world-level items.
+
+**Files:**
+- Create: `vtmtools-bridge/scripts/foundry-actions/item.js`
+- Modify: `vtmtools-bridge/scripts/foundry-actions/bridge.js` (register `item: itemsSubscriber` in the `subscribers` map)
+
+**Anti-scope:** Do NOT report embedded actor items here (filter `if (item.parent !== null) return;` in every hook). Do NOT emit any wire variant beyond the three specified in Task 1.
+
+**Depends on:** none (JS-only, parallel with Rust work)
+
+**Invariants cited:** Helper-library roadmap §4 (per-umbrella files; handler-map dispatch). The existing `actorsSubscriber` is the canonical template.
+
+**Tests required:** NO — JS side has no unit-test infrastructure in this repo. Manual smoke against a live Foundry world covers it (Task 16).
+
+- [ ] **Step 1: Create `item.js`**
+
+Create `vtmtools-bridge/scripts/foundry-actions/item.js`:
+
+```js
+// Foundry item.* subscriber executor.
+//
+// World-level Item docs only — embedded-on-actor items continue to flow
+// through actorsSubscriber's per-actor enrichment. The filter is
+// `item.parent === null` on every Foundry Item Document hook event.
+//
+// Wire emission shapes (consumed by Rust FoundryInbound; see
+// src-tauri/src/bridge/foundry/types.rs):
+//   { type: "items",                  items: [...] }    // snapshot on attach
+//   { type: "world_item_upsert",      item: {...} }     // create OR update
+//   { type: "world_item_deleted",     item_id: "..." }  // delete
+
+const MODULE_ID = "vtmtools-bridge";
+
+let _attached = null; // { socket, hookHandles: [ids] }
+
+function itemToWire(item) {
+  return {
+    id: item.id,
+    name: item.name,
+    type: item.type,
+    featuretype: item.system?.featuretype ?? null,
+    system: item.system ?? {},
+  };
+}
+
+function isWorldLevel(item) {
+  // Foundry parents: world items have parent === null; embedded items
+  // have parent === <Actor>.
+  return item.parent === null || item.parent === undefined;
+}
+
+export const itemsSubscriber = {
+  attach(socket) {
+    if (_attached) return;
+    if (socket?.readyState === WebSocket.OPEN) {
+      const items = game.items.contents
+        .filter(isWorldLevel)
+        .map(itemToWire);
+      socket.send(JSON.stringify({ type: "items", items }));
+      console.log(`[${MODULE_ID}] itemsSubscriber: pushed ${items.length} world items`);
+    }
+
+    const onCreate = Hooks.on("createItem", (item /*, options, userId */) => {
+      if (!isWorldLevel(item)) return;
+      socket.send(JSON.stringify({ type: "world_item_upsert", item: itemToWire(item) }));
+    });
+    const onUpdate = Hooks.on("updateItem", (item /*, changes, options, userId */) => {
+      if (!isWorldLevel(item)) return;
+      socket.send(JSON.stringify({ type: "world_item_upsert", item: itemToWire(item) }));
+    });
+    const onDelete = Hooks.on("deleteItem", (item /*, options, userId */) => {
+      if (!isWorldLevel(item)) return;
+      socket.send(JSON.stringify({ type: "world_item_deleted", item_id: item.id }));
+    });
+
+    _attached = { socket, hookHandles: { createItem: onCreate, updateItem: onUpdate, deleteItem: onDelete } };
+  },
+
+  detach() {
+    if (!_attached) return;
+    Hooks.off("createItem", _attached.hookHandles.createItem);
+    Hooks.off("updateItem", _attached.hookHandles.updateItem);
+    Hooks.off("deleteItem", _attached.hookHandles.deleteItem);
+    _attached = null;
+  },
+};
+```
+
+- [ ] **Step 2: Register `item` collection in `bridge.js` subscribers map**
+
+In `vtmtools-bridge/scripts/foundry-actions/bridge.js`, add the import and registration:
+
+```js
+import { actorsSubscriber } from "./actor.js";
+import { itemsSubscriber } from "./item.js";
+
+const subscribers = {
+  actors: actorsSubscriber,
+  item: itemsSubscriber,
+};
+```
+
+**Collection name:** `item` (singular) matches the spec sketch's `collection: "item"` envelope. The desktop will send `bridge.subscribe { collection: "item" }` to activate it.
+
+- [ ] **Step 3: Manual smoke (deferred to Task 16)**
+
+Smoke verification is part of Task 16's E2E gate. For this task's verification: confirm `npm run check` (frontend type-check has no opinion on the bridge module — JS module is loaded by Foundry runtime, not by SvelteKit).
+
+- [ ] **Step 4: Commit**
+
+```
+git add vtmtools-bridge/scripts/foundry-actions/item.js \
+        vtmtools-bridge/scripts/foundry-actions/bridge.js
+git commit -m "$(cat <<'EOF'
+Add Foundry item.* subscriber (world-level items only)
+
+New itemsSubscriber attaches to bridge.subscribe { collection: "item" }
+and pushes initial snapshot + per-item upserts/deletes via createItem,
+updateItem, deleteItem hooks. Filter is `item.parent === null` so
+embedded-on-actor items continue to arrive only via actorsSubscriber's
+enrichment.
+
+Refs #27.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 7: New JS `foundry-actions/world.js` with `createWorldItem` handler
+
+**Goal:** Outbound side of #13. New ES module that handles `world.create_item` envelopes by calling `Item.create({...})` at world level.
+
+**Files:**
+- Create: `vtmtools-bridge/scripts/foundry-actions/world.js`
+- Modify: `vtmtools-bridge/scripts/foundry-actions/index.js` (register `worldHandlers`)
+
+**Anti-scope:** Do NOT add other `world.*` helpers in this milestone — the umbrella is reserved but only one handler ships. Do NOT touch embedded actor items here (those are actor.*).
+
+**Depends on:** none (JS-only, parallel)
+
+**Invariants cited:** Helper-library roadmap §4 (umbrella-per-file), §6 (naming conventions: wire `type` = `world.create_item`; JS executor name = camelCase verb-noun `createWorldItem`).
+
+**Tests required:** NO (manual smoke covers it in Task 16).
+
+- [ ] **Step 1: Create `world.js`**
+
+Create `vtmtools-bridge/scripts/foundry-actions/world.js`:
+
+```js
+// Foundry world.* helper executors.
+//
+// World-level operations not tied to a single actor. The world.* umbrella
+// is reserved by name in foundry helper roadmap §5; v1 milestone-4
+// ships exactly one helper: world.create_item (used by Library Sync
+// push button to create a Foundry-world-level Item doc that lives in
+// the world's Items sidebar / compendium, not embedded on an actor).
+
+const MODULE_ID = "vtmtools-bridge";
+
+/**
+ * Create a world-level Item document.
+ * Wire shape (validated Rust-side; see build_create_world_item):
+ *   { type: "world.create_item", name, featuretype, description, points }
+ * Effect: Item.create({ type: "feature", name,
+ *                       system: { featuretype, description, points } })
+ *         at world level (no parent actor).
+ * Failure modes: Foundry permission errors (GM-only — should not occur
+ *                given the bridge runs in a GM session); duplicate name
+ *                is NOT rejected (Foundry allows duplicate-name items).
+ * Idempotency: NOT idempotent. Re-running creates a duplicate row.
+ *              Dedup is Plan C's concern (auto-version-suffix on pull).
+ */
+async function createWorldItem(msg) {
+  try {
+    await Item.create({
+      type: "feature",
+      name: msg.name,
+      system: {
+        featuretype: msg.featuretype,
+        description: msg.description ?? "",
+        points: typeof msg.points === "number" ? msg.points : 0,
+      },
+    });
+  } catch (err) {
+    console.error(`[${MODULE_ID}] world.create_item failed:`, err);
+    ui.notifications?.error(`vtmtools: could not create world item: ${err?.message ?? err}`);
+    throw err;
+  }
+}
+
+export const handlers = {
+  "world.create_item": createWorldItem,
+};
+```
+
+- [ ] **Step 2: Register in `index.js`**
+
+In `vtmtools-bridge/scripts/foundry-actions/index.js`, add:
+
+```js
+import { handlers as actorHandlers }       from "./actor.js";
+import { handlers as bridgeHandlers }      from "./bridge.js";
+import { handlers as gameHandlers }        from "./game.js";
+import { handlers as storytellerHandlers } from "./storyteller.js";
+import { handlers as worldHandlers }       from "./world.js";
+
+export const handlers = {
+  ...actorHandlers,
+  ...bridgeHandlers,
+  ...gameHandlers,
+  ...storytellerHandlers,
+  ...worldHandlers,
+};
+```
+
+- [ ] **Step 3: Commit**
+
+```
+git add vtmtools-bridge/scripts/foundry-actions/world.js \
+        vtmtools-bridge/scripts/foundry-actions/index.js
+git commit -m "$(cat <<'EOF'
+Add Foundry world.* umbrella + world.create_item handler
+
+Reserves world.* on the wire (foundry helper roadmap §5) and ships
+exactly one v1 helper: world.create_item creates a world-level
+feature Item doc (merit / flaw / background / boon). Used by Plan B
+push to send a local advantage row into the active Foundry world.
+
+Not idempotent — dedup is Plan C's concern.
+
+Refs #13.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 8: Bump `module.json` 0.5.0 → 0.6.0
+
+**Goal:** Reflect the additive `item` subscription + `world.*` umbrella in the module version.
+
+**Files:**
+- Modify: `vtmtools-bridge/module.json`
+
+**Anti-scope:** Do NOT bump the protocol_version field (still 1 — additive features only).
+
+**Depends on:** Tasks 6, 7
+
+**Invariants cited:** Helper-library roadmap §7 (additive features = minor bump).
+
+**Tests required:** NO
+
+- [ ] **Step 1: Bump version**
+
+Change `module.json`'s `"version": "0.5.0"` to `"version": "0.6.0"`.
+
+- [ ] **Step 2: Commit**
+
+```
+git add vtmtools-bridge/module.json
+git commit -m "$(cat <<'EOF'
+vtmtools-bridge: 0.5.0 → 0.6.0 (item subscription + world.* umbrella)
+
+Additive features within protocol_version 1:
+  • bridge.subscribe accepts collection: "item" (#27)
+  • world.create_item handler (#13)
+
+Backward compat: old desktop ↔ new module works identically (desktop
+never sends bridge.subscribe { item } unless on Plan B+).
+
+Refs #13 #27.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 9: New Rust `bridge/foundry/actions/world.rs` with `build_create_world_item`
+
+**Goal:** Rust-side builder for the `world.create_item` wire envelope. Validates featuretype against the same merit/flaw/background/boon enum that `actor.create_feature` uses.
+
+**Files:**
+- Create: `src-tauri/src/bridge/foundry/actions/world.rs`
+- Modify: `src-tauri/src/bridge/foundry/actions/mod.rs` — add `pub mod world;`
+
+**Anti-scope:** Do NOT duplicate the validation logic — extract a shared helper if `actor.rs::build_create_feature`'s validation is already factored out, OR copy the 4-line `match` if not (no abstraction wanted per the YAGNI override).
+
+**Depends on:** none (Rust-only, parallel with JS tasks)
+
+**Invariants cited:** ARCH §7 (error prefix `foundry/world.create_item:`). Helper-library roadmap §6 (builder naming convention).
+
+**Tests required:** YES — 2 tests (happy path envelope shape + invalid featuretype rejection).
+
+- [ ] **Step 1: Create `world.rs`**
+
+Create `src-tauri/src/bridge/foundry/actions/world.rs`:
+
+```rust
+//! Foundry `world.*` helper builders. World-level operations not tied
+//! to a single actor.
+//!
+//! v1 milestone-4 ships exactly one helper: `world.create_item` —
+//! creates a Foundry-world-level Item doc (feature type) with the
+//! given featuretype (merit / flaw / background / boon).
+
+use serde_json::{json, Value};
+
+/// Build a `world.create_item { name, featuretype, description, points }`
+/// envelope. Validates featuretype against the same enum
+/// `actor.create_feature` uses.
+pub fn build_create_world_item(
+    name: &str,
+    featuretype: &str,
+    description: &str,
+    points: i32,
+) -> Result<Value, String> {
+    match featuretype {
+        "merit" | "flaw" | "background" | "boon" => {}
+        other => {
+            return Err(format!(
+                "foundry/world.create_item: invalid featuretype: {other}"
+            ));
+        }
+    }
+    Ok(json!({
+        "type": "world.create_item",
+        "name": name,
+        "featuretype": featuretype,
+        "description": description,
+        "points": points,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_world_item_envelope_shape() {
+        let out = build_create_world_item("Iron Gullet", "merit", "rancid blood ok", 3)
+            .expect("merit is a valid featuretype");
+        assert_eq!(out["type"], "world.create_item");
+        assert_eq!(out["name"], "Iron Gullet");
+        assert_eq!(out["featuretype"], "merit");
+        assert_eq!(out["description"], "rancid blood ok");
+        assert_eq!(out["points"], 3);
+    }
+
+    #[test]
+    fn create_world_item_invalid_featuretype_returns_err() {
+        let err = build_create_world_item("X", "discipline", "", 0)
+            .expect_err("discipline is not a valid featuretype");
+        assert!(
+            err.starts_with("foundry/world.create_item: invalid featuretype:"),
+            "got: {err}"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Register the module**
+
+In `src-tauri/src/bridge/foundry/actions/mod.rs`:
+
+```rust
+pub mod actor;
+pub mod bridge;
+pub mod game;
+pub mod storyteller;
+pub mod world;
+```
+
+- [ ] **Step 3: Run `cargo test`**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml bridge::foundry::actions::world`
+
+Expected: 2 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```
+git add src-tauri/src/bridge/foundry/actions/world.rs \
+        src-tauri/src/bridge/foundry/actions/mod.rs
+git commit -m "$(cat <<'EOF'
+Add Rust builder for world.create_item envelope
+
+Validates featuretype against merit/flaw/background/boon. Mirrors the
+Foundry-side world.js executor; pairing enforced by integration test
+in Task 16's E2E smoke.
+
+Refs #13.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 10: New Rust `tools/library_push.rs` with `push_advantage_to_world`
+
+**Goal:** Tauri command that loads an advantage row by id, maps `kind → featuretype` (lossless — they're 1:1), composes `world.create_item`, and routes via `send_to_source_inner(SourceKind::Foundry)`.
+
+**Files:**
+- Create: `src-tauri/src/tools/library_push.rs`
+- Modify: `src-tauri/src/tools/mod.rs` — add `pub mod library_push;`
+
+**Anti-scope:** Do NOT push dyscrasias here. Do NOT iterate over multiple advantages — `push_advantage_to_world(id)` is single-row; bulk push (if ever wanted) is a frontend loop. Do NOT cache the SourceKind::Foundry connectivity state — `send_to_source_inner` already returns Ok if disconnected.
+
+**Depends on:** Task 9 (builder); Plan A (Advantage struct has `kind`).
+
+**Invariants cited:** ARCH §4 (Tauri IPC; typed wrappers required at frontend). ARCH §7 (error prefix `tools/library_push:`).
+
+**Tests required:** YES — 1 happy-path test using an in-memory pool + a faked outbound channel via a temporary `BridgeState` that captures sent messages.
+
+- [ ] **Step 1: Create `library_push.rs`**
+
+Create `src-tauri/src/tools/library_push.rs`:
+
+```rust
+//! Library push: send a local advantage row → active Foundry world as a
+//! world-level Item doc. Composes
+//! `bridge::foundry::actions::world::build_create_world_item`. No-op if
+//! Foundry isn't connected (silent success — matches bridge_set_attribute
+//! semantics; the UI gates the button on connectivity).
+
+use crate::bridge::foundry::actions::world::build_create_world_item;
+use crate::bridge::types::SourceKind;
+use crate::bridge::{commands::send_to_source_inner, BridgeConn};
+use crate::shared::types::AdvantageKind;
+use tauri::State;
+
+fn kind_to_featuretype(k: AdvantageKind) -> &'static str {
+    match k {
+        AdvantageKind::Merit      => "merit",
+        AdvantageKind::Flaw       => "flaw",
+        AdvantageKind::Background => "background",
+        AdvantageKind::Boon       => "boon",
+    }
+}
+
+fn extract_points(properties: &[crate::shared::types::Field]) -> i32 {
+    // Look for `level` (single-value) or fall back to `min_level`.
+    // Anything not found → 0. Mirrors the existing AdvantagesManager
+    // dot-display fallback.
+    for f in properties {
+        if f.name == "level" || f.name == "min_level" {
+            if let crate::shared::types::FieldValue::Number { value } = &f.value {
+                match value {
+                    crate::shared::types::NumberFieldValue::Single(n) => return *n as i32,
+                    crate::shared::types::NumberFieldValue::Range(min, _) => return *min as i32,
+                }
+            }
+        }
+    }
+    0
+}
+
+#[tauri::command]
+pub async fn push_advantage_to_world(
+    db: State<'_, crate::DbState>,
+    conn: State<'_, BridgeConn>,
+    id: i64,
+) -> Result<(), String> {
+    // Load the advantage row by id (read-only — uses listAdvantages
+    // path; cheaper than a per-id query at v1 scale, and consistent
+    // with the rest of the module).
+    let all = crate::db::advantage::__internal_db_list(&db.0).await?;
+    let row = all.iter().find(|r| r.id == id)
+        .ok_or_else(|| format!("tools/library_push: advantage {id} not found"))?;
+
+    let payload = build_create_world_item(
+        &row.name,
+        kind_to_featuretype(row.kind),
+        &row.description,
+        extract_points(&row.properties),
+    )?;
+
+    let text = serde_json::to_string(&payload)
+        .map_err(|e| format!("tools/library_push: serialize: {e}"))?;
+    send_to_source_inner(&conn.0, SourceKind::Foundry, text).await
+}
+
+#[cfg(test)]
+mod tests {
+    // Note: this test depends on db::advantage having a public-or-
+    // pub(crate) db_list helper. If db_list is private, add a
+    // pub(crate) re-export named __internal_db_list in db/advantage.rs.
+    // Verify the helper visibility before adding the test.
+
+    // Happy-path integration test goes here once db_list is exposed.
+    // Defers to Task 16's E2E smoke if module-internal helper
+    // visibility blocks a clean unit test.
+}
+```
+
+**Implementation note on `__internal_db_list`:** the existing `db::advantage::db_list` is private to the module. Promote it to `pub(crate)` (rename optional — `db_list` is fine for the crate-internal name) so `tools/library_push` can read advantages without going through Tauri state from a Tauri command. Update `db/advantage.rs` to add `pub(crate)` to the function signature.
+
+- [ ] **Step 2: Promote `db_list` to `pub(crate)`**
+
+In `src-tauri/src/db/advantage.rs`, change `async fn db_list(...)` to `pub(crate) async fn db_list(...)`. Use this from `library_push.rs` directly: `crate::db::advantage::db_list(&db.0).await`.
+
+Drop the `__internal_db_list` rename in the snippet above; just use `db_list`.
+
+- [ ] **Step 3: Register the module**
+
+In `src-tauri/src/tools/mod.rs`:
+
+```rust
+pub mod library_push;
+// (alongside existing pub mod entries)
+```
+
+- [ ] **Step 4: Add unit test**
+
+In `library_push.rs::tests`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared::types::{Advantage, AdvantageKind, Field, FieldValue, NumberFieldValue};
+
+    #[test]
+    fn extract_points_reads_level_field() {
+        let props = vec![Field {
+            name: "level".into(),
+            value: FieldValue::Number { value: NumberFieldValue::Single(3.0) },
+        }];
+        assert_eq!(extract_points(&props), 3);
+    }
+
+    #[test]
+    fn extract_points_reads_min_level_for_ranged() {
+        let props = vec![Field {
+            name: "min_level".into(),
+            value: FieldValue::Number { value: NumberFieldValue::Single(1.0) },
+        }];
+        assert_eq!(extract_points(&props), 1);
+    }
+
+    #[test]
+    fn extract_points_returns_zero_when_absent() {
+        assert_eq!(extract_points(&[]), 0);
+    }
+
+    #[test]
+    fn kind_maps_to_featuretype_one_to_one() {
+        assert_eq!(kind_to_featuretype(AdvantageKind::Merit),      "merit");
+        assert_eq!(kind_to_featuretype(AdvantageKind::Flaw),       "flaw");
+        assert_eq!(kind_to_featuretype(AdvantageKind::Background), "background");
+        assert_eq!(kind_to_featuretype(AdvantageKind::Boon),       "boon");
+    }
+}
+```
+
+Full integration (DB → builder → outbound channel) is covered by Task 16's manual E2E smoke. Unit tests cover the two pure helpers.
+
+- [ ] **Step 5: Run `cargo test`**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml tools::library_push`
+
+Expected: 4 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src-tauri/src/tools/library_push.rs \
+        src-tauri/src/tools/mod.rs \
+        src-tauri/src/db/advantage.rs
+git commit -m "$(cat <<'EOF'
+Add push_advantage_to_world Tauri command
+
+Loads local advantage row by id; maps Plan-A's kind → featuretype 1:1;
+composes world.create_item via the Plan-B builder; routes through the
+existing send_to_source_inner outbound path. No-op when Foundry is
+disconnected (matches bridge_set_attribute semantics).
+
+Promotes db::advantage::db_list to pub(crate) so library_push can
+read without going through a fresh Tauri state lookup.
+
+Refs #13.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 11: Register `push_advantage_to_world` in `lib.rs`
+
+**Goal:** Wire the new command into Tauri's `invoke_handler!` so the frontend can call it.
+
+**Files:**
+- Modify: `src-tauri/src/lib.rs`
+
+**Anti-scope:** Do NOT touch the `bridge_get_world_items` line (Task 5 already added that). Do NOT register Plan C's `import_advantages_from_world` (that's Plan C's territory).
+
+**Depends on:** Tasks 5, 10
+
+**Invariants cited:** ARCH §9 ("Add a Tauri command" seam).
+
+**Tests required:** NO
+
+- [ ] **Step 1: Add to `invoke_handler!`**
+
+In `src-tauri/src/lib.rs`, in the `generate_handler![...]` list, add:
+
+```rust
+tools::library_push::push_advantage_to_world,
+```
+
+near the other `tools::` entries (e.g., next to `tools::foundry_chat::*`).
+
+- [ ] **Step 2: Run `./scripts/verify.sh`**
+
+Expected: green.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src-tauri/src/lib.rs
+git commit -m "$(cat <<'EOF'
+Register push_advantage_to_world in invoke_handler
+
+Command surface 64 → 65 (bridge_get_world_items + push_advantage_to_world
+both new in Plan B; ARCHITECTURE.md §4 update follows in Task 15).
+
+Refs #13.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 12: Frontend typed wrapper `src/lib/library/api.ts`
+
+**Goal:** Establish the `library` namespace on the frontend with the single Plan-B wrapper. Plan C extends this file with `importAdvantagesFromWorld`.
+
+**Files:**
+- Create: `src/lib/library/api.ts`
+
+**Anti-scope:** Do NOT add any other wrapper (Plan C territory). Do NOT call `invoke` from components.
+
+**Depends on:** Task 11
+
+**Invariants cited:** ARCH §4 (typed wrappers per command; components never call `invoke` directly).
+
+**Tests required:** NO
+
+- [ ] **Step 1: Create `src/lib/library/api.ts`**
+
+```ts
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * Push a local advantage row → active Foundry world as a world-level
+ * feature Item doc. No-op if Foundry isn't connected (silent success
+ * at the IPC layer; the UI gates the button on bridge connectivity).
+ *
+ * Resolves on success; rejects with a `"tools/library_push: ..."`
+ * string if the advantage id is unknown or the wire envelope fails to
+ * serialize. Bridge-disconnected case is NOT an error.
+ */
+export function pushAdvantageToWorld(id: number): Promise<void> {
+  return invoke<void>('push_advantage_to_world', { id });
+}
+```
+
+- [ ] **Step 2: Run `npm run check`**
+
+Expected: green.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/lib/library/api.ts
+git commit -m "$(cat <<'EOF'
+Add src/lib/library/api.ts typed wrapper
+
+Namespace established with pushAdvantageToWorld (Plan B). Plan C
+extends this file with importAdvantagesFromWorld.
+
+Refs #13.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 13: `src/store/bridge.svelte.ts` reactive `worldItems` state
+
+**Goal:** Hydrate world-items on mount via `bridge_get_world_items`; subscribe to `bridge://foundry/items-updated` for live updates. Mirrors the existing characters-updated pattern.
+
+**Files:**
+- Modify: `src/store/bridge.svelte.ts`
+
+**Anti-scope:** Do NOT add per-source partitioning logic in the store — keep a flat `worldItems: CanonicalWorldItem[]` (each item carries its `source` field; consumers filter as needed). Do NOT auto-subscribe to `item` collection here — the desktop sends `bridge.subscribe` only when a consumer needs it (Plan C's "Pull from world" trigger), so subscription registration is Plan C's concern.
+
+**Depends on:** Tasks 2, 5
+
+**Invariants cited:** ARCH §3 (ephemeral state in Svelte runes stores); ARCH §4 (Tauri events table).
+
+**Tests required:** NO
+
+- [ ] **Step 1: Read current `bridge.svelte.ts` structure**
+
+Locate the existing characters-updated subscription. The pattern: on mount, call `invoke('bridge_get_characters')`; subscribe to `bridge://characters-updated` and replace `characters` state on each emit.
+
+- [ ] **Step 2: Add `worldItems` state and subscription**
+
+Add `let worldItems: CanonicalWorldItem[] = $state([])` and an `unlisten` for `bridge://foundry/items-updated`. Hydrate on init via a wrapper call. Use the same lifecycle pattern as `characters` — the goal is a drop-in mirror.
+
+If the store has a single `init()` that registers all subscriptions, append the items-updated listener there. If it's per-piece-of-state, copy the characters pattern verbatim with `worldItems` substituted.
+
+- [ ] **Step 3: Add a typed wrapper for `bridge_get_world_items`**
+
+In `src/lib/bridge/api.ts` (or wherever existing `bridge_*` wrappers live):
+
+```ts
+export function bridgeGetWorldItems(): Promise<CanonicalWorldItem[]> {
+  return invoke<CanonicalWorldItem[]>('bridge_get_world_items');
+}
+```
+
+- [ ] **Step 4: Run `npm run check` and `npm run build`**
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/store/bridge.svelte.ts src/lib/bridge/api.ts
+git commit -m "$(cat <<'EOF'
+bridge store: hydrate + subscribe to world items
+
+Mirrors the characters-updated pattern. Hydrate via
+bridge_get_world_items on mount; subscribe to
+bridge://foundry/items-updated for live deltas. Plan C consumes
+this store for the import-from-world flow.
+
+Refs #27.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 14: AdvantagesManager "Push to world" button
+
+**Goal:** Per-row button visible only when Foundry is connected; on click calls `pushAdvantageToWorld(id)`; success → toast; error → error toast.
+
+**Files:**
+- Modify: `src/tools/AdvantagesManager.svelte` (or `src/lib/components/AdvantageCard.svelte` if the per-row action area lives there)
+
+**Anti-scope:** Do NOT add a "Push all" bulk button — single-row only. Do NOT pre-check duplicate name on the Foundry side — push is allowed even if a same-name item exists (Foundry allows duplicates; dedup is Plan C's concern for the **import** direction).
+
+**Depends on:** Tasks 12, 13
+
+**Invariants cited:** ARCH §6 (CSS tokens only; no hardcoded hex).
+
+**Tests required:** NO (manual smoke covers it).
+
+- [ ] **Step 1: Find the per-row action surface**
+
+Locate where each row's actions render (probably in `AdvantageCard.svelte`'s footer). The existing "Edit" and "Delete" buttons live there.
+
+- [ ] **Step 2: Add "Push to world" button**
+
+Add a button next to Edit/Delete:
+
+```svelte
+<script lang="ts">
+  import { pushAdvantageToWorld } from '$lib/library/api';
+  import { bridgeStore } from '$lib/../store/bridge.svelte';
+
+  let pushing = $state(false);
+  let pushError = $state('');
+</script>
+
+{#if bridgeStore.status.foundry}
+  <button class="row-action" disabled={pushing}
+    onclick={async () => {
+      pushing = true;
+      pushError = '';
+      try {
+        await pushAdvantageToWorld(adv.id);
+        // Optional: toast "Pushed '<name>' to <world>"
+      } catch (e) {
+        pushError = String(e);
+      } finally {
+        pushing = false;
+      }
+    }}>
+    {pushing ? '…' : '⇡ Push to world'}
+  </button>
+  {#if pushError}
+    <span class="error-inline">{pushError}</span>
+  {/if}
+{/if}
+```
+
+The `bridgeStore.status.foundry` predicate gates visibility — disconnected sessions don't render the button at all. (Adapt the store accessor name to match whatever the existing pattern is in `bridge.svelte.ts`.)
+
+CSS — reuse the existing row-action button styling. No new tokens.
+
+- [ ] **Step 3: Run `npm run check` and `npm run build`**
+
+Expected: green.
+
+- [ ] **Step 4: Manual smoke**
+
+`npm run tauri dev` with a Foundry world running and the bridge connected:
+
+- ✅ Push button visible on each row.
+- ✅ Click "Push to world" on a corebook merit → Foundry world's Items sidebar shows a new "Iron Gullet" feature item with featuretype = merit.
+- ✅ Click again → second duplicate appears (push is non-idempotent; dedup is Plan C territory).
+- ✅ Disconnect Foundry → push buttons disappear (or grey out, depending on the reactive guard).
+- ✅ Push a custom Boon → world Item appears with featuretype = boon.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/tools/AdvantagesManager.svelte \
+        src/lib/components/AdvantageCard.svelte
+git commit -m "$(cat <<'EOF'
+AdvantagesManager: add per-row "Push to world" button
+
+Visible only when Foundry is connected (gated on bridgeStore.status.
+foundry). Composes pushAdvantageToWorld(id); error toasted inline.
+Non-idempotent — duplicate pushes create duplicate world items.
+
+Closes #13.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 15: ARCHITECTURE.md §4 updates
+
+**Goal:** Document the new IPC command + new event + bridge protocol additions.
+
+**Files:**
+- Modify: `ARCHITECTURE.md`
+
+**Anti-scope:** Do NOT add Plan C's commands here (Plan C territory). Do NOT introduce new sections — append to existing inventory entries.
+
+**Depends on:** Task 14
+
+**Invariants cited:** CLAUDE.md: every new `#[tauri::command]` requires updating ARCHITECTURE.md §4 IPC inventory.
+
+**Tests required:** NO
+
+- [ ] **Step 1: Update IPC inventory**
+
+In §4, update the `src-tauri/src/tools/library_push.rs` entry:
+
+```
+- **`src-tauri/src/tools/library_push.rs`** (1):
+  `push_advantage_to_world`.
+```
+
+(If the file doesn't yet have an entry, add it adjacent to `tools/foundry_chat.rs`.)
+
+Update `src-tauri/src/bridge/commands.rs` entry: append `bridge_get_world_items` and bump count from 6 to 7. Update the running total at the bottom of the IPC section from 63 to 65.
+
+- [ ] **Step 2: Update Tauri events table**
+
+In §4 Tauri events, add a row:
+
+| `bridge://foundry/items-updated` | `Vec<CanonicalWorldItem>` | Foundry pushed a world-level item snapshot or delta (subscribed via `bridge.subscribe { collection: "item" }`); carries the merged cache across all sources |
+
+- [ ] **Step 3: Update Bridge WebSocket protocol section**
+
+In §4 Bridge WebSocket protocol, after the existing message-framing paragraph, add a paragraph on the `item` subscription and `world.*` umbrella:
+
+> **Subscription collections (Foundry):** `actors` (auto-subscribed on Hello — always-on; preserves pre-Plan-0 behavior), `item` (opt-in via `bridge.subscribe { collection: "item" }` — Plan B+ Library Sync consumers). The subscription registry lives in `vtmtools-bridge/scripts/foundry-actions/bridge.js`; future collections (`journal`, `scene`, `chat`, `combat`) are reserved by name in the character-tooling roadmap §5 and activated when a consumer feature lands.
+>
+> **Outbound umbrellas (Foundry):** `actor.*` (per-actor edits), `game.*` (in-game/table rolls + chat), `world.*` (world-level operations; v1 ships `world.create_item` only — Library Sync push), `storyteller.*` (reserved, no helpers in v1). See `docs/superpowers/specs/2026-04-26-foundry-helper-library-roadmap.md` for the per-helper inventory.
+
+- [ ] **Step 4: Run `./scripts/verify.sh`**
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add ARCHITECTURE.md
+git commit -m "$(cat <<'EOF'
+ARCHITECTURE.md: document Plan-B IPC + bridge additions
+
+§4 IPC inventory:
+  + tools/library_push.rs (1): push_advantage_to_world
+  + bridge/commands.rs +1: bridge_get_world_items (was 6, now 7)
+  + total 63 → 65
+
+§4 Tauri events table: + bridge://foundry/items-updated
+
+§4 Bridge WebSocket protocol: documents `item` subscription
+collection and `world.*` outbound umbrella.
+
+Refs #13 #27.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 16: Final verification gate (incl. live-Foundry E2E smoke)
+
+**Goal:** Confirm Plan B end-to-end against a live Foundry world before handing off to Plan C.
+
+- [ ] **Step 1: Run `./scripts/verify.sh`**
+
+Expected: full green.
+
+- [ ] **Step 2: Live-Foundry smoke — push side (#13)**
+
+Boot the Tauri app + a Foundry world with `vtmtools-bridge@0.6.0` installed.
+
+- ✅ Bridge connects (green pip).
+- ✅ Open Advantages tool → "Push to world" buttons appear on every row.
+- ✅ Click push on "Iron Gullet" merit → Foundry world's Items sidebar shows a new "Iron Gullet" entry with type=Feature and (in the WoD5e sheet view) Feature Type=Merit.
+- ✅ Click push on "Prey Exclusion" flaw → same path, featuretype=Flaw.
+- ✅ Push a custom row with kind=Boon → appears as featuretype=Boon.
+
+- [ ] **Step 3: Live-Foundry smoke — subscription side (#27)**
+
+(Without Plan C's import UI, the desktop never sends `bridge.subscribe { item }` automatically. Test by manually triggering subscription from the JS console of the Foundry browser session OR by waiting for Plan C.)
+
+Manual triggering option — paste into the Foundry browser console with the bridge connected:
+
+```js
+// Force the desktop to subscribe to item collection (test-only).
+// Plan C's importer will trigger this automatically.
+const ws = game.modules.get("vtmtools-bridge")?._socket;
+// (or whatever accessor — this depends on how bridge.js exposes the socket;
+//  may need to inspect bridge.js to see if the socket is reachable from
+//  the console for testing purposes. If not, defer this smoke to Plan C.)
+```
+
+If manual triggering proves unreachable, mark this smoke as **DEFER TO PLAN C** in the verification log — Plan C's importer flow tests the subscription end-to-end naturally.
+
+- [ ] **Step 4: Update plan checkboxes**
+
+Mark every Task 1–15 step as `[x]` in this file. Commit:
+
+```
+git add docs/superpowers/plans/2026-05-14-library-sync-plan-b-push-and-item-subscription.md
+git commit -m "$(cat <<'EOF'
+Mark Plan B tasks complete
+
+Plan B (push + item subscription) shipped. Closes #13 #27.
+Unblocks Plan C (pull + attribution + dedup).
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+Plan B is complete. Plan C may now dispatch.

--- a/docs/superpowers/plans/2026-05-14-library-sync-plan-c-pull-attribution-dedup.md
+++ b/docs/superpowers/plans/2026-05-14-library-sync-plan-c-pull-attribution-dedup.md
@@ -1,0 +1,1138 @@
+# Library Sync — Plan C: Pull + attribution + dedup
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Project lean-execution override (CLAUDE.md):** dispatch ONE implementer subagent per task with full task text + scene-setting context, run `./scripts/verify.sh` after the implementer commits, then move on. After ALL Plan C tasks are committed (i.e., after the last of Plans A + B + C lands), run a SINGLE `code-review:code-review` against the full Phase 4 branch diff.
+>
+> **TDD-on-demand override (CLAUDE.md):** subagents do NOT auto-invoke `superpowers:test-driven-development`. Each task below explicitly states whether tests are required.
+
+**Goal:** Close the import half of Library Sync:
+- **#14 — Pull library items ← Foundry world.** Add a "Pull from active world" action to the Advantages tool. On click, send `bridge.subscribe { collection: "item" }` (Plan B shipped the wire path), wait for the snapshot, filter to feature-type items (merit/flaw/background/boon), present a confirmation summary, then write rows to the local `advantages` table with `is_custom = 1` + populated `source_attribution`. Disciplines are out of scope for this milestone (deferred per architect recommendation; reservation paragraph added to ARCHITECTURE.md in Plan A).
+- **#15 — Source-attribution surfacing.** Render a source chip on each AdvantagesManager row whose `source_attribution` is non-null. Reuses the `SourceAttributionChip` component already shipped in Phase 1.
+- **#16 — Dedup / conflict resolution.** Auto-version-suffix on local name collision: `<name> (FVTT — <world>)`. No interactive prompt, no review modal. Collision is detected against the SAME `(name, kind, source_attribution.world)` triple — two same-name merits from different worlds coexist by world-suffix; pulling the SAME merit twice from the SAME world is treated as an update (preserves row id, refreshes attribution timestamp).
+
+**Architecture:** Plan B's `item` subscription delivers `CanonicalWorldItem` rows into `BridgeState.world_items` and emits `bridge://foundry/items-updated` on every change. Plan C's importer is a Tauri command `import_advantages_from_world` that snapshot-reads the bridge cache (no new wire trip — the data is already in-memory), filters to `kind == "feature"` items with featuretype ∈ {merit, flaw, background, boon}, applies dedup-suffix logic against existing local rows, INSERTs new rows / UPDATEs matching world+name rows, and returns a per-row outcome list (`[{name, kind, action: 'inserted' | 'updated' | 'skipped'}]`) for UI summary.
+
+**Subscription lifecycle:** The "Pull from world" button is the ONLY consumer of the `item` subscription in v1. Plan C's import flow:
+1. Frontend calls `bridge_subscribe(SourceKind::Foundry, 'item')` (a thin wrapper new in Plan C, since auto-subscribe-on-mount would be wasteful).
+2. Waits up to 2 seconds for the next `bridge://foundry/items-updated` event (or uses the existing cache if already populated).
+3. Calls `import_advantages_from_world()` Tauri command.
+4. Frontend optionally calls `bridge_unsubscribe(SourceKind::Foundry, 'item')` to stop further updates (low cost to leave subscribed; recommend leaving subscribed for the session so re-imports show fresh data).
+
+The Tauri-side subscribe/unsubscribe wrappers are new — Plan 0 shipped the `bridge.subscribe` JSON envelope, but no Tauri command exposed it (auto-subscribe-actors was hardcoded in `bridge.js`). Plan C is the first consumer to need a dynamic subscribe path.
+
+**Tech Stack:** Rust (`sqlx`, `serde`, `serde_json`, `tauri`, `chrono`), TypeScript / Svelte 5 runes, SQLite.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-character-tooling-roadmap.md` §5 Phase 4 (sketch) + architect-advisor recommendation. Source sketches in GitHub issues #14, #15, #16.
+
+**Architecture reference:** `ARCHITECTURE.md` §3 (storage strategy — `is_custom` tri-state post-Plan-A), §4 (IPC inventory — adds 3 new commands), §5 (only `db/*` talks to SQLite), §7 (error prefix `db/advantage.import:`), §9 ("Add a Tauri command" + the "Add a library kind" rule from Plan A).
+
+**Depends on:**
+- Plan A — `Advantage.kind` enum + `source_attribution` column + tri-state `is_custom`.
+- Plan B — `bridge.subscribe { collection: "item" }` wire path + `BridgeState.world_items` cache + `bridge://foundry/items-updated` event.
+
+**Issues closed:** #14, #15, #16. Milestone 4 complete.
+
+---
+
+## File structure
+
+### New files
+- `src/lib/library/importer.ts` — pure TS functions: `dedupeKey(name, kind, world)`, `collideAndSuffix(name, world)`, `summarizeImport(outcomes)`. Pure helpers; testable without IPC. Used by the frontend "Pull" button to format the post-import toast.
+- `src-tauri/src/db/advantage_import.rs` (or extend `db/advantage.rs` — see Task 1 for which) — `import_advantages_from_world(state, world_title)` Tauri command that reads the bridge cache, dedupes, inserts/updates, returns outcomes.
+- (Optionally) `src/lib/components/PullFromWorldButton.svelte` — small wrapper for the button + loading state + summary modal/toast. Decide in Task 6 whether this earns its own component or stays inline in AdvantagesManager.
+
+### Modified files
+- `src-tauri/src/db/advantage.rs` — add `db_find_by_dedup_key(pool, name, kind, world) -> Result<Option<Advantage>, String>` (looks up `WHERE name = ? AND kind = ? AND json_extract(source_attribution, '$.worldTitle') = ?`); add `db_upsert_imported(pool, name, kind, description, properties, source_attribution) -> Result<ImportOutcome, String>` that runs the dedup-suffix logic.
+- `src-tauri/src/bridge/commands.rs` — add `bridge_subscribe(source: SourceKind, collection: String)` + `bridge_unsubscribe(source: SourceKind, collection: String)` Tauri commands that compose `bridge::foundry::actions::bridge::build_subscribe / build_unsubscribe` and route via `send_to_source_inner`.
+- `src-tauri/src/lib.rs` — register `import_advantages_from_world`, `bridge_subscribe`, `bridge_unsubscribe` in `invoke_handler!`.
+- `src/lib/library/api.ts` — extend with `importAdvantagesFromWorld(): Promise<ImportOutcome[]>` + `subscribeToWorldItems(): Promise<void>` + `unsubscribeFromWorldItems(): Promise<void>` typed wrappers.
+- `src/tools/AdvantagesManager.svelte` — add "Pull from world" button (Foundry-connected only); on click → subscribe → wait/snapshot → import → summary toast. Add source chip on rows with non-null `sourceAttribution`. Add tri-state filter chip (corebook / local / imported) to the existing filter row.
+- `src/lib/components/AdvantageCard.svelte` — render the source chip (reuse Phase 1's `SourceAttributionChip`).
+- `src/types.ts` — add `ImportOutcome` discriminated union (`'inserted' | 'updated' | 'skipped'`).
+- `ARCHITECTURE.md` §4 — append `bridge_subscribe`, `bridge_unsubscribe`, `import_advantages_from_world` to IPC inventory; bump total 65 → 68.
+
+### Files explicitly NOT touched
+- `src-tauri/src/bridge/foundry/types.rs` — Plan B frozen.
+- `src-tauri/src/bridge/foundry/actions/world.rs` — Plan B frozen (push side only; Plan C is pull).
+- `vtmtools-bridge/scripts/*` — Plan B frozen (the JS-side `item` subscriber + `world.*` umbrella are stable).
+- `src-tauri/src/db/dyscrasia.rs` — separate row shape; out of scope.
+- Disciplines schema — deferred per partitioning rule.
+
+---
+
+## Task overview
+
+| # | Task | Depends on | Tests |
+|---|---|---|---|
+| 1 | Add `db::advantage::db_find_by_dedup_key` + `db_upsert_imported` + tests | Plan A | YES (4-5 tests covering dedup branches) |
+| 2 | Add `import_advantages_from_world` Tauri command (reads bridge cache + DB) | 1 | YES (1 integration test against in-memory pool + fake `world_items` cache) |
+| 3 | Add `bridge_subscribe` + `bridge_unsubscribe` Tauri commands | none (independent of 1/2) | NO (compose existing builders; covered by manual smoke in Task 8) |
+| 4 | Register 3 new commands in `lib.rs` | 1, 2, 3 | NO |
+| 5 | Extend `src/lib/library/api.ts` + add `importer.ts` pure helpers + tests | 4 | YES (vitest if available; otherwise skip — verify the testing convention in the repo first) |
+| 6 | Update `AdvantagesManager.svelte` with Pull button + source chip + tri-state filter | 5 + Plan A's existing UI work | NO (manual smoke covers it) |
+| 7 | ARCHITECTURE.md §4 updates | 6 | NO |
+| 8 | Final verification gate (incl. live-Foundry pull smoke) | all | runs `./scripts/verify.sh` + manual E2E |
+
+Tasks 1 and 3 are independent and can dispatch in parallel. Task 2 depends on Task 1. Tasks 5–7 are sequential after Task 4.
+
+---
+
+## Task 1: DB helpers — `db_find_by_dedup_key` + `db_upsert_imported`
+
+**Goal:** Two new internal helpers in `db/advantage.rs` that own the dedup-and-import logic at the DB layer. Tauri-callable wrapper sits on top in Task 2.
+
+**Dedup rule (architect lock-in):** Two advantages are "the same" iff they share `(name, kind, source_attribution->>worldTitle)`. World key comes from JSON path `$.worldTitle`. If both rows are local (`source_attribution IS NULL`), then `name + kind` is the dedup key — but that case is impossible at import time because every imported row has non-null attribution. The unique-suffix collision case for import is therefore: imported `<name>` collides with an existing LOCAL row of same name + kind (different attribution state) → suffix becomes `<name> (FVTT — <world>)`.
+
+**Files:**
+- Modify: `src-tauri/src/db/advantage.rs`
+
+**Anti-scope:** Do NOT add a Tauri command in this task. Do NOT touch the existing `db_insert` / `db_update` / `db_delete` paths — the import path is a parallel function with its own semantics.
+
+**Depends on:** Plan A (`AdvantageKind`, `source_attribution` column).
+
+**Invariants cited:** ARCH §5 (only `db/*` talks to SQLite), §7 (error prefix `db/advantage.import:` and `db/advantage.find_by_dedup_key:`).
+
+**Tests required:** YES — 4 tests minimum.
+
+- [ ] **Step 1: Add `db_find_by_dedup_key`**
+
+In `src-tauri/src/db/advantage.rs`, near the other internal helpers:
+
+```rust
+pub(crate) async fn db_find_by_dedup_key(
+    pool: &SqlitePool,
+    name: &str,
+    kind: AdvantageKind,
+    world_title: &str,
+) -> Result<Option<Advantage>, String> {
+    let kind_str = kind_to_str(kind);
+    let rows = sqlx::query(
+        "SELECT id, name, description, tags_json, properties_json, is_custom,
+                kind, source_attribution
+         FROM advantages
+         WHERE name = ?
+           AND kind = ?
+           AND json_extract(source_attribution, '$.worldTitle') = ?
+         LIMIT 1"
+    )
+    .bind(name)
+    .bind(kind_str)
+    .bind(world_title)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| format!("db/advantage.find_by_dedup_key: {e}"))?;
+
+    match rows {
+        Some(r) => {
+            let tags_json: String = r.get("tags_json");
+            let properties_json: String = r.get("properties_json");
+            let kind_db: String = r.get("kind");
+            let source_attribution: Option<String> = r.try_get("source_attribution").ok();
+            Ok(Some(Advantage {
+                id: r.get("id"),
+                name: r.get("name"),
+                description: r.get("description"),
+                kind: str_to_kind(&kind_db)?,
+                tags: deserialize_tags(&tags_json)?,
+                properties: deserialize_properties(&properties_json)?,
+                is_custom: r.get::<bool, _>("is_custom"),
+                source_attribution: source_attribution
+                    .and_then(|s| serde_json::from_str(&s).ok()),
+            }))
+        }
+        None => Ok(None),
+    }
+}
+```
+
+- [ ] **Step 2: Add `db_collides_locally`**
+
+Helper that detects collision against any row with the same name+kind regardless of attribution (for the suffix path):
+
+```rust
+pub(crate) async fn db_collides_locally(
+    pool: &SqlitePool,
+    name: &str,
+    kind: AdvantageKind,
+) -> Result<bool, String> {
+    let kind_str = kind_to_str(kind);
+    let row = sqlx::query("SELECT COUNT(*) as c FROM advantages WHERE name = ? AND kind = ?")
+        .bind(name)
+        .bind(kind_str)
+        .fetch_one(pool)
+        .await
+        .map_err(|e| format!("db/advantage.collides_locally: {e}"))?;
+    let c: i64 = row.get("c");
+    Ok(c > 0)
+}
+```
+
+- [ ] **Step 3: Add the `ImportOutcome` enum + `db_upsert_imported`**
+
+Add to `shared/types.rs` (since it crosses the IPC boundary):
+
+```rust
+/// Outcome of one import attempt for a single world item.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum ImportOutcome {
+    /// Row didn't exist locally. Inserted as-is (may include world-suffix
+    /// in the name if a same-name local row already existed).
+    Inserted { id: i64, name: String, kind: AdvantageKind },
+    /// Same (name, kind, world) already imported here. Updated description
+    /// + bumped imported_at; row id preserved.
+    Updated  { id: i64, name: String, kind: AdvantageKind },
+    /// Filtered out (non-feature item.kind, or unrecognized featuretype).
+    Skipped  { reason: String, name: String },
+}
+```
+
+Then in `db/advantage.rs`:
+
+```rust
+use crate::shared::types::ImportOutcome;
+
+/// Insert-or-update an imported advantage row.
+///
+/// Dedup logic:
+///   1. If a row exists with (name, kind, source_attribution.worldTitle)
+///      = (in_name, in_kind, in_world) → UPDATE description + bump
+///      source_attribution.importedAt; preserve row id; return Updated.
+///   2. Else if a local row exists with (name, kind) but DIFFERENT
+///      attribution (or null attribution) → suffix the import name as
+///      "<name> (FVTT — <world>)"; INSERT; return Inserted.
+///   3. Else → INSERT as-is; return Inserted.
+pub(crate) async fn db_upsert_imported(
+    pool: &SqlitePool,
+    name: &str,
+    kind: AdvantageKind,
+    description: &str,
+    properties: &[Field],
+    source_attribution: &serde_json::Value,
+) -> Result<ImportOutcome, String> {
+    let world_title = source_attribution.get("worldTitle")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "db/advantage.upsert_imported: source_attribution missing worldTitle".to_string())?;
+
+    // Case 1: exact same (name, kind, world) — Update.
+    if let Some(existing) = db_find_by_dedup_key(pool, name, kind, world_title).await? {
+        let props_json = serialize_properties(properties)?;
+        let attr_str = serde_json::to_string(source_attribution)
+            .map_err(|e| format!("db/advantage.upsert_imported: serialize attribution: {e}"))?;
+        sqlx::query(
+            "UPDATE advantages
+             SET description = ?, properties_json = ?, source_attribution = ?
+             WHERE id = ?"
+        )
+        .bind(description)
+        .bind(&props_json)
+        .bind(&attr_str)
+        .bind(existing.id)
+        .execute(pool)
+        .await
+        .map_err(|e| format!("db/advantage.upsert_imported: update: {e}"))?;
+
+        return Ok(ImportOutcome::Updated {
+            id: existing.id,
+            name: existing.name,
+            kind: existing.kind,
+        });
+    }
+
+    // Case 2: name+kind collision with different attribution → suffix.
+    let final_name = if db_collides_locally(pool, name, kind).await? {
+        format!("{name} (FVTT — {world_title})")
+    } else {
+        name.to_string()
+    };
+
+    // Case 2 / Case 3: INSERT.
+    let props_json = serialize_properties(properties)?;
+    let tags_json = serialize_tags(&Vec::<String>::new())?; // tags empty for imports; GM can edit later
+    let attr_str = serde_json::to_string(source_attribution)
+        .map_err(|e| format!("db/advantage.upsert_imported: serialize attribution: {e}"))?;
+    let kind_str = kind_to_str(kind);
+
+    let result = sqlx::query(
+        "INSERT INTO advantages
+            (name, description, kind, tags_json, properties_json, is_custom, source_attribution)
+         VALUES (?, ?, ?, ?, ?, 1, ?)"
+    )
+    .bind(&final_name)
+    .bind(description)
+    .bind(kind_str)
+    .bind(&tags_json)
+    .bind(&props_json)
+    .bind(&attr_str)
+    .execute(pool)
+    .await
+    .map_err(|e| format!("db/advantage.upsert_imported: insert: {e}"))?;
+
+    Ok(ImportOutcome::Inserted {
+        id: result.last_insert_rowid(),
+        name: final_name,
+        kind,
+    })
+}
+```
+
+- [ ] **Step 4: Tests**
+
+In the existing `#[cfg(test)] mod tests` block:
+
+```rust
+fn world_attribution(world: &str) -> serde_json::Value {
+    serde_json::json!({
+        "source": "foundry",
+        "worldTitle": world,
+        "importedAt": "2026-05-14T12:00:00Z",
+    })
+}
+
+#[tokio::test]
+async fn upsert_imported_new_row_inserts() {
+    let pool = test_pool().await;
+    let out = db_upsert_imported(&pool, "Iron Gullet", AdvantageKind::Merit,
+        "desc", &[], &world_attribution("Chicago")).await.unwrap();
+    assert!(matches!(out, ImportOutcome::Inserted { name, .. } if name == "Iron Gullet"));
+}
+
+#[tokio::test]
+async fn upsert_imported_same_world_updates_in_place() {
+    let pool = test_pool().await;
+    let first = db_upsert_imported(&pool, "Iron Gullet", AdvantageKind::Merit,
+        "desc1", &[], &world_attribution("Chicago")).await.unwrap();
+    let first_id = match first { ImportOutcome::Inserted { id, .. } => id, _ => panic!() };
+
+    let second = db_upsert_imported(&pool, "Iron Gullet", AdvantageKind::Merit,
+        "desc2 (revised)", &[], &world_attribution("Chicago")).await.unwrap();
+
+    match second {
+        ImportOutcome::Updated { id, .. } => assert_eq!(id, first_id),
+        other => panic!("expected Updated, got {other:?}"),
+    }
+    let rows = db_list(&pool).await.unwrap();
+    assert_eq!(rows.iter().filter(|r| r.name == "Iron Gullet").count(), 1);
+    assert_eq!(rows.iter().find(|r| r.id == first_id).unwrap().description, "desc2 (revised)");
+}
+
+#[tokio::test]
+async fn upsert_imported_different_world_suffixes_name() {
+    let pool = test_pool().await;
+    db_upsert_imported(&pool, "Iron Gullet", AdvantageKind::Merit, "d", &[],
+        &world_attribution("Chicago")).await.unwrap();
+
+    let second = db_upsert_imported(&pool, "Iron Gullet", AdvantageKind::Merit, "d", &[],
+        &world_attribution("Berlin")).await.unwrap();
+
+    match second {
+        ImportOutcome::Inserted { name, .. } => {
+            assert_eq!(name, "Iron Gullet (FVTT — Berlin)");
+        }
+        other => panic!("expected Inserted with suffix, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn upsert_imported_suffixes_against_local_row() {
+    let pool = test_pool().await;
+    // Pre-existing local (non-imported) row.
+    db_insert(&pool, "Iron Gullet", "local desc", AdvantageKind::Merit, None, &[], &[]).await.unwrap();
+
+    let imported = db_upsert_imported(&pool, "Iron Gullet", AdvantageKind::Merit, "fvtt desc", &[],
+        &world_attribution("Chicago")).await.unwrap();
+
+    match imported {
+        ImportOutcome::Inserted { name, .. } => {
+            assert_eq!(name, "Iron Gullet (FVTT — Chicago)");
+        }
+        other => panic!("expected Inserted with suffix, got {other:?}"),
+    }
+    let rows = db_list(&pool).await.unwrap();
+    let names: Vec<_> = rows.iter().map(|r| r.name.as_str()).collect();
+    assert!(names.contains(&"Iron Gullet"));
+    assert!(names.contains(&"Iron Gullet (FVTT — Chicago)"));
+}
+
+#[tokio::test]
+async fn find_by_dedup_key_returns_none_for_local_row() {
+    let pool = test_pool().await;
+    db_insert(&pool, "Allies", "local", AdvantageKind::Background, None, &[], &[]).await.unwrap();
+    let found = db_find_by_dedup_key(&pool, "Allies", AdvantageKind::Background, "Chicago").await.unwrap();
+    assert!(found.is_none(), "local row (NULL attribution) must not match world-keyed dedup");
+}
+```
+
+- [ ] **Step 5: Run `cargo test`**
+
+Run: `cargo test --manifest-path src-tauri/Cargo.toml db::advantage`
+
+Expected: all existing tests + 5 new tests pass.
+
+- [ ] **Step 6: Run `./scripts/verify.sh`**
+
+Expected: green.
+
+- [ ] **Step 7: Commit**
+
+```
+git add src-tauri/src/db/advantage.rs src-tauri/src/shared/types.rs
+git commit -m "$(cat <<'EOF'
+db/advantage: add dedup-and-import helpers
+
+db_find_by_dedup_key looks up (name, kind, source_attribution.worldTitle).
+db_collides_locally detects any (name, kind) match regardless of
+attribution. db_upsert_imported is the import-flow workhorse:
+  • same world → UPDATE in place (idempotent re-imports)
+  • different world → auto-suffix "(FVTT — <world>)"
+  • no collision → straight INSERT
+
+ImportOutcome enum carries Inserted / Updated / Skipped variants
+across the IPC boundary. 5 new tests cover every branch.
+
+Refs #14 #15 #16.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 2: `import_advantages_from_world` Tauri command
+
+**Goal:** Read `BridgeState.world_items` for the Foundry source, filter to feature-type items, call `db_upsert_imported` for each, return the outcome list. Single-shot Tauri command; the frontend is responsible for triggering subscription first (Task 6 wires that).
+
+**Files:**
+- Modify: `src-tauri/src/db/advantage.rs` (add the Tauri command)
+
+**Anti-scope:** Do NOT subscribe to `item` collection here — the subscription has to be triggered before the command runs (frontend handles via `bridge_subscribe` in Task 3). Do NOT delete local rows here (deletion is the GM's manual concern). Do NOT operate on dyscrasias.
+
+**Depends on:** Task 1
+
+**Invariants cited:** ARCH §4 (typed wrappers required), §7 (error prefix `db/advantage.import_from_world:`).
+
+**Tests required:** YES — 1 integration test that constructs an in-memory `BridgeState` with a faked `world_items` cache and asserts the outcome list.
+
+- [ ] **Step 1: Add the Tauri command**
+
+In `src-tauri/src/db/advantage.rs`:
+
+```rust
+use crate::bridge::{BridgeConn, types::SourceKind};
+
+/// Import feature-type world items from the active Foundry world into
+/// the local advantages library. Pulls from BridgeState.world_items —
+/// the frontend must have subscribed to `item` collection beforehand.
+///
+/// Filter: only `kind == "feature"` items with featuretype ∈ {merit,
+/// flaw, background, boon}. Other item kinds (speciality, power, etc.)
+/// are silently filtered (returned as Skipped outcomes for UI summary).
+///
+/// Per-item: composes db_upsert_imported. Returns Vec<ImportOutcome>
+/// in iteration order (which is HashMap order — unspecified, but the
+/// frontend doesn't care about ordering).
+#[tauri::command]
+pub async fn import_advantages_from_world(
+    db: tauri::State<'_, crate::DbState>,
+    bridge: tauri::State<'_, BridgeConn>,
+) -> Result<Vec<ImportOutcome>, String> {
+    // Pull world snapshot + source info.
+    let world_title = {
+        let info = bridge.0.source_info.lock().await;
+        info.get(&SourceKind::Foundry)
+            .and_then(|i| i.world_title.clone())
+            .ok_or_else(|| "db/advantage.import_from_world: no active Foundry world (connect first?)".to_string())?
+    };
+    let world_id = {
+        let info = bridge.0.source_info.lock().await;
+        info.get(&SourceKind::Foundry)
+            .and_then(|i| i.world_id.clone())
+    };
+    let system_version = {
+        let info = bridge.0.source_info.lock().await;
+        info.get(&SourceKind::Foundry)
+            .and_then(|i| i.system_version.clone())
+    };
+
+    let items: Vec<crate::bridge::types::CanonicalWorldItem> = {
+        let store = bridge.0.world_items.lock().await;
+        store.get(&SourceKind::Foundry)
+            .map(|m| m.values().cloned().collect())
+            .unwrap_or_default()
+    };
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let attribution_base = serde_json::json!({
+        "source": "foundry",
+        "worldTitle": world_title,
+        "worldId": world_id,
+        "systemVersion": system_version,
+        "importedAt": now,
+    });
+
+    let mut outcomes = Vec::with_capacity(items.len());
+    for item in items {
+        if item.kind != "feature" {
+            outcomes.push(ImportOutcome::Skipped {
+                reason: format!("non-feature item kind: {}", item.kind),
+                name: item.name,
+            });
+            continue;
+        }
+        let ft = match item.featuretype.as_deref() {
+            Some("merit")      => AdvantageKind::Merit,
+            Some("flaw")       => AdvantageKind::Flaw,
+            Some("background") => AdvantageKind::Background,
+            Some("boon")       => AdvantageKind::Boon,
+            other => {
+                outcomes.push(ImportOutcome::Skipped {
+                    reason: format!("unknown featuretype: {:?}", other),
+                    name: item.name,
+                });
+                continue;
+            }
+        };
+
+        // Extract description + points from item.system.
+        let description = item.system.get("description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let points = item.system.get("points")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32;
+
+        // Build properties (level field) for downstream UI consistency.
+        let properties: Vec<Field> = if points > 0 {
+            vec![Field {
+                name: "level".into(),
+                value: FieldValue::Number { value: NumberFieldValue::Single(points as f64) },
+            }]
+        } else {
+            vec![]
+        };
+
+        let outcome = db_upsert_imported(
+            &db.0,
+            &item.name,
+            ft,
+            &description,
+            &properties,
+            &attribution_base,
+        ).await?;
+        outcomes.push(outcome);
+    }
+
+    Ok(outcomes)
+}
+```
+
+Add the necessary imports at the top of `db/advantage.rs`:
+
+```rust
+use crate::shared::types::{Field, FieldValue, NumberFieldValue};
+```
+
+(`chrono` is in `Cargo.toml` already — verify; if not, this is a YAGNI win — use `std::time::SystemTime` + manual ISO-8601 formatting via existing helpers.)
+
+- [ ] **Step 2: Integration test**
+
+```rust
+#[tokio::test]
+async fn import_from_world_filters_non_feature_and_unknown_featuretype() {
+    let pool = test_pool().await;
+
+    // Stub out a BridgeState with a faked world_items cache.
+    // The test helper needs to construct a minimal BridgeConn — see
+    // src-tauri/src/bridge/mod.rs for the existing test-state helper
+    // if it exists, otherwise add a fixture here using
+    // BridgeState::new_test() pattern.
+
+    // For v1, this integration test is BEST-EFFORT: if BridgeState's
+    // test fixtures don't yet exist (likely they don't), defer the
+    // integration test to manual E2E and only ship unit tests for
+    // db_upsert_imported (Task 1). Document this gap in the task
+    // tracker.
+
+    // Pseudo-test sketch:
+    //   let bridge = BridgeConn::new_test_with_world_items(vec![
+    //       CanonicalWorldItem { kind: "feature", featuretype: Some("merit".into()), ... },
+    //       CanonicalWorldItem { kind: "speciality", featuretype: None, ... },
+    //       CanonicalWorldItem { kind: "feature", featuretype: Some("discipline".into()), ... },
+    //   ]);
+    //   let outcomes = import_advantages_from_world(db_state, bridge).await.unwrap();
+    //   assert_eq!(outcomes.len(), 3);
+    //   assert!(matches!(outcomes[0], ImportOutcome::Inserted { .. }));
+    //   assert!(matches!(outcomes[1], ImportOutcome::Skipped { reason, .. } if reason.contains("non-feature")));
+    //   assert!(matches!(outcomes[2], ImportOutcome::Skipped { reason, .. } if reason.contains("unknown featuretype")));
+}
+```
+
+**Implementation note:** if `BridgeConn` lacks test-fixture support, mark this test `#[ignore]` with a comment pointing to Task 8's E2E smoke, OR refactor `import_advantages_from_world` to take an injectable items-source — both are fine. The 5 unit tests on `db_upsert_imported` (Task 1) carry the dedup logic correctness; this integration test would only cover the filter+orchestration shell.
+
+- [ ] **Step 3: Run `cargo test`**
+
+Expected: existing tests still pass; new integration test passes OR is marked `#[ignore]` with rationale.
+
+- [ ] **Step 4: Commit**
+
+```
+git add src-tauri/src/db/advantage.rs
+git commit -m "$(cat <<'EOF'
+Add import_advantages_from_world Tauri command
+
+Reads BridgeState.world_items for the Foundry source, filters to
+feature-type items with merit/flaw/background/boon featuretype,
+composes db_upsert_imported per row. Returns Vec<ImportOutcome>
+for the frontend summary toast. Stamps source_attribution with
+world title + world id + system version + ISO-8601 importedAt.
+
+Subscription to `item` collection must be triggered by the frontend
+before calling (Task 6); this command is a snapshot reader.
+
+Refs #14 #15.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 3: `bridge_subscribe` + `bridge_unsubscribe` Tauri commands
+
+**Goal:** First-class Tauri commands for dynamically subscribing to a Foundry collection. Plan 0 shipped the wire envelope; Plan C is the first dynamic consumer.
+
+**Files:**
+- Modify: `src-tauri/src/bridge/commands.rs`
+
+**Anti-scope:** Do NOT couple these to Foundry — they accept a `SourceKind` parameter so future per-source subscriptions work. Do NOT track subscribed state in `BridgeState` here — the source (module) tracks it; desktop is fire-and-forget at the IPC layer.
+
+**Depends on:** none (uses existing `actions::bridge::build_subscribe / build_unsubscribe` and `send_to_source_inner`).
+
+**Invariants cited:** ARCH §4 (Tauri IPC), §7 (error prefix `bridge/subscribe:` / `bridge/unsubscribe:`).
+
+**Tests required:** NO — composes existing primitives; manual smoke in Task 8.
+
+- [ ] **Step 1: Add the commands**
+
+In `src-tauri/src/bridge/commands.rs`:
+
+```rust
+use crate::bridge::foundry::actions::bridge as bridge_actions;
+
+/// Send `bridge.subscribe { collection }` to the named source. No-op
+/// if the source isn't connected. Per-source dispatch: in v1 only
+/// Foundry implements bridge.* subscriptions; Roll20 silently ignores.
+#[tauri::command]
+pub async fn bridge_subscribe(
+    conn: State<'_, BridgeConn>,
+    source: SourceKind,
+    collection: String,
+) -> Result<(), String> {
+    // v1: only Foundry implements bridge.subscribe. Future sources may
+    // route via SourceKind here.
+    if source != SourceKind::Foundry {
+        return Err(format!("bridge/subscribe: source {source:?} does not support subscriptions"));
+    }
+    let payload = bridge_actions::build_subscribe(&collection);
+    let text = serde_json::to_string(&payload)
+        .map_err(|e| format!("bridge/subscribe: serialize: {e}"))?;
+    send_to_source_inner(&conn.0, source, text).await
+}
+
+/// Send `bridge.unsubscribe { collection }` to the named source.
+#[tauri::command]
+pub async fn bridge_unsubscribe(
+    conn: State<'_, BridgeConn>,
+    source: SourceKind,
+    collection: String,
+) -> Result<(), String> {
+    if source != SourceKind::Foundry {
+        return Err(format!("bridge/unsubscribe: source {source:?} does not support subscriptions"));
+    }
+    let payload = bridge_actions::build_unsubscribe(&collection);
+    let text = serde_json::to_string(&payload)
+        .map_err(|e| format!("bridge/unsubscribe: serialize: {e}"))?;
+    send_to_source_inner(&conn.0, source, text).await
+}
+```
+
+- [ ] **Step 2: Run `cargo check`**
+
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src-tauri/src/bridge/commands.rs
+git commit -m "$(cat <<'EOF'
+Add bridge_subscribe / bridge_unsubscribe Tauri commands
+
+First dynamic consumer of Plan 0's bridge.subscribe envelope. Plan C
+import flow drives these from the AdvantagesManager Pull button.
+v1 accepts only SourceKind::Foundry (Roll20 returns an error string
+rather than silently ignoring — gives the frontend a clearer signal).
+
+Refs #14.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 4: Register 3 new commands in `lib.rs`
+
+**Goal:** Wire all new commands into the invoke handler.
+
+**Files:**
+- Modify: `src-tauri/src/lib.rs`
+
+**Depends on:** Tasks 1, 2, 3
+
+**Tests required:** NO
+
+- [ ] **Step 1: Add three lines**
+
+In `invoke_handler!`:
+
+```rust
+db::advantage::import_advantages_from_world,
+bridge::commands::bridge_subscribe,
+bridge::commands::bridge_unsubscribe,
+```
+
+(Cluster `import_advantages_from_world` near `db::advantage::*`; cluster the `bridge_*` ones near other `bridge::commands::*` entries.)
+
+- [ ] **Step 2: Run `./scripts/verify.sh`**
+
+Expected: green.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src-tauri/src/lib.rs
+git commit -m "$(cat <<'EOF'
+Register Plan C commands in invoke_handler
+
+import_advantages_from_world, bridge_subscribe, bridge_unsubscribe.
+Command surface 65 → 68. ARCHITECTURE.md §4 update follows in Task 7.
+
+Refs #14 #16.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 5: Frontend typed wrappers + `importer.ts` helpers
+
+**Goal:** Extend `src/lib/library/api.ts` with the three new wrappers; add `importer.ts` with the pure summarization helpers.
+
+**Files:**
+- Modify: `src/lib/library/api.ts`
+- Create: `src/lib/library/importer.ts`
+- Modify: `src/types.ts` (add `ImportOutcome` discriminated union)
+
+**Anti-scope:** Do NOT call `invoke` from components. Do NOT add a SubscriptionState store — the frontend can fire-and-forget; the post-import refresh of the advantages list is the only state-of-interest.
+
+**Depends on:** Task 4
+
+**Invariants cited:** ARCH §4 (typed wrappers per Tauri command).
+
+**Tests required:** NO required, but if the repo has vitest set up, add 2-3 tests for the pure `importer.ts` helpers.
+
+- [ ] **Step 1: Add `ImportOutcome` to `src/types.ts`**
+
+```ts
+export type AdvantageKind = 'merit' | 'flaw' | 'background' | 'boon';
+
+export type ImportOutcome =
+  | { action: 'inserted'; id: number; name: string; kind: AdvantageKind }
+  | { action: 'updated';  id: number; name: string; kind: AdvantageKind }
+  | { action: 'skipped';  reason: string; name: string };
+```
+
+(Verify `AdvantageKind` is already in `src/types.ts` from Plan A — should be.)
+
+- [ ] **Step 2: Extend `src/lib/library/api.ts`**
+
+```ts
+import { invoke } from '@tauri-apps/api/core';
+import type { ImportOutcome } from '../../types';
+
+export function pushAdvantageToWorld(id: number): Promise<void> {
+  return invoke<void>('push_advantage_to_world', { id });
+}
+
+export function importAdvantagesFromWorld(): Promise<ImportOutcome[]> {
+  return invoke<ImportOutcome[]>('import_advantages_from_world');
+}
+
+export function subscribeToWorldItems(): Promise<void> {
+  return invoke<void>('bridge_subscribe',
+    { source: 'foundry', collection: 'item' });
+}
+
+export function unsubscribeFromWorldItems(): Promise<void> {
+  return invoke<void>('bridge_unsubscribe',
+    { source: 'foundry', collection: 'item' });
+}
+```
+
+**SourceKind serialization note:** Rust's `SourceKind` enum serializes as `"foundry"` / `"roll20"` (snake_case). Verify by inspecting `src-tauri/src/bridge/types.rs` for the serde attribute on `SourceKind` (around line 5).
+
+- [ ] **Step 3: Create `src/lib/library/importer.ts`**
+
+```ts
+import type { ImportOutcome } from '../../types';
+
+export interface ImportSummary {
+  inserted: number;
+  updated: number;
+  skipped: number;
+  details: ImportOutcome[];
+}
+
+/**
+ * Summarize a list of import outcomes for the UI toast.
+ * Pure; no IPC; no side effects.
+ */
+export function summarizeImport(outcomes: ImportOutcome[]): ImportSummary {
+  let inserted = 0, updated = 0, skipped = 0;
+  for (const o of outcomes) {
+    if (o.action === 'inserted')      inserted++;
+    else if (o.action === 'updated')  updated++;
+    else                              skipped++;
+  }
+  return { inserted, updated, skipped, details: outcomes };
+}
+
+/**
+ * Format the summary as a single-line toast message.
+ * "Imported 4 new (2 updated, 1 skipped) from Chronicles of Chicago"
+ */
+export function summaryAsToast(summary: ImportSummary, worldTitle: string): string {
+  const parts: string[] = [];
+  parts.push(`Imported ${summary.inserted} new`);
+  const suffixes: string[] = [];
+  if (summary.updated > 0) suffixes.push(`${summary.updated} updated`);
+  if (summary.skipped > 0) suffixes.push(`${summary.skipped} skipped`);
+  if (suffixes.length > 0) parts.push(`(${suffixes.join(', ')})`);
+  parts.push(`from ${worldTitle}`);
+  return parts.join(' ');
+}
+```
+
+- [ ] **Step 4: Run `npm run check`**
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/lib/library/api.ts src/lib/library/importer.ts src/types.ts
+git commit -m "$(cat <<'EOF'
+Add Plan C frontend wrappers + import summarization helpers
+
+api.ts: importAdvantagesFromWorld, subscribeToWorldItems,
+unsubscribeFromWorldItems. Composes Plan B's pushAdvantageToWorld for
+the full Library Sync IPC surface.
+
+importer.ts: pure summarizeImport + summaryAsToast helpers used by
+AdvantagesManager's Pull button (Task 6).
+
+ImportOutcome TS discriminated union mirrors the Rust enum.
+
+Refs #14.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 6: AdvantagesManager UI — Pull button, source chip, tri-state filter
+
+**Goal:** The visible deliverable of Phase 4. Three discrete UI additions:
+1. "⇣ Pull from active world" button (Foundry-connected only).
+2. Source chip on each row whose `sourceAttribution` is non-null. Reuses Phase 1's `SourceAttributionChip.svelte`.
+3. Tri-state filter row: `Corebook / Local / Imported` (mutually exclusive with each other but additive to the existing tag and kind filters).
+
+**Files:**
+- Modify: `src/tools/AdvantagesManager.svelte`
+- Modify: `src/lib/components/AdvantageCard.svelte` (source chip slot)
+- Verify: `src/components/SourceAttributionChip.svelte` is reusable here — confirm prop shape (likely `world: string`, `source: 'foundry' | 'roll20'`).
+
+**Anti-scope:** Do NOT show an interactive collision-resolution modal — auto-suffix is locked in (#16 decision). Do NOT add a "Re-pull" button on individual rows — pull-all-and-update is the v1 model. Do NOT add per-row Delete for imported items (the existing Delete button on custom rows works for them too — they're `is_custom = 1`).
+
+**Depends on:** Tasks 4, 5 (commands + wrappers).
+
+**Invariants cited:** ARCH §4 (typed wrappers only — no direct `invoke`), §6 (CSS tokens; no hardcoded hex).
+
+**Tests required:** NO (UI; manual smoke covers it).
+
+- [ ] **Step 1: Verify `SourceAttributionChip.svelte`**
+
+Read `src/components/SourceAttributionChip.svelte`. Note its props. Adapt the per-row chip to pass `{ source: 'foundry', world: adv.sourceAttribution?.worldTitle }`. If the prop shape doesn't fit, the import-version chip can be inline:
+
+```svelte
+{#if adv.sourceAttribution}
+  <span class="chip source-chip" data-source="foundry">
+    FVTT · {adv.sourceAttribution.worldTitle}
+  </span>
+{/if}
+```
+
+- [ ] **Step 2: Add the "Pull from active world" button**
+
+In `AdvantagesManager.svelte`'s toolbar area (near the existing Sort/Filter controls):
+
+```svelte
+<script lang="ts">
+  import {
+    importAdvantagesFromWorld,
+    subscribeToWorldItems,
+    unsubscribeFromWorldItems,
+  } from '$lib/library/api';
+  import { summarizeImport, summaryAsToast } from '$lib/library/importer';
+  import { bridgeStore } from '$lib/../store/bridge.svelte';
+
+  let pulling = $state(false);
+  let pullSummary = $state('');
+  let pullError = $state('');
+
+  async function pullFromWorld() {
+    pulling = true;
+    pullSummary = '';
+    pullError = '';
+    try {
+      await subscribeToWorldItems();
+      // Wait briefly for the snapshot to arrive — 1.5s covers
+      // typical Foundry response latency on localhost. The
+      // bridge cache may already be hot (subscribed in prior pull
+      // this session); the wait is no-cost in that case.
+      await new Promise(r => setTimeout(r, 1500));
+      const outcomes = await importAdvantagesFromWorld();
+      const summary = summarizeImport(outcomes);
+      const worldTitle = bridgeStore.sourceInfo?.foundry?.worldTitle ?? 'Foundry';
+      pullSummary = summaryAsToast(summary, worldTitle);
+      // Reload local rows so the new imports + chips render.
+      await loadAll();
+    } catch (e) {
+      pullError = String(e);
+    } finally {
+      pulling = false;
+    }
+  }
+</script>
+
+{#if bridgeStore.status.foundry}
+  <button class="toolbar-action" disabled={pulling} onclick={pullFromWorld}>
+    {pulling ? 'Pulling…' : '⇣ Pull from world'}
+  </button>
+  {#if pullSummary}
+    <span class="toolbar-status">{pullSummary}</span>
+  {/if}
+  {#if pullError}
+    <span class="toolbar-error">{pullError}</span>
+  {/if}
+{/if}
+```
+
+(Adapt `bridgeStore` accessors to match Plan B's actual exports.)
+
+- [ ] **Step 3: Add source chip on rows**
+
+In `src/lib/components/AdvantageCard.svelte`, near the kind chip from Plan A:
+
+```svelte
+{#if adv.sourceAttribution}
+  <span class="chip source-chip" data-source={adv.sourceAttribution.source}>
+    FVTT · {adv.sourceAttribution.worldTitle}
+  </span>
+{/if}
+```
+
+CSS:
+
+```css
+.source-chip[data-source="foundry"] {
+  background: var(--accent-foundry, var(--accent-muted));
+  font-size: 0.75rem;
+}
+```
+
+- [ ] **Step 4: Add tri-state filter**
+
+Extend `AdvantagesManager.svelte`'s state:
+
+```ts
+type ProvenanceFilter = 'all' | 'corebook' | 'local' | 'imported';
+let provenanceFilter: ProvenanceFilter = $state('all');
+
+function matchesProvenance(adv: Advantage): boolean {
+  switch (provenanceFilter) {
+    case 'all':      return true;
+    case 'corebook': return !adv.isCustom;
+    case 'local':    return adv.isCustom && !adv.sourceAttribution;
+    case 'imported': return adv.isCustom && !!adv.sourceAttribution;
+  }
+}
+```
+
+Include `matchesProvenance` in the existing `visible` derived chain:
+
+```ts
+const visible = $derived(
+  sortRows(allEntries.filter(e => matchesTags(e) && matchesQuery(e) && matchesProvenance(e)))
+);
+```
+
+Render a small chip row with 4 buttons (`All / Corebook / Local / Imported`) using the same chip styling as tags. Mutually exclusive — clicking one sets it as `provenanceFilter`.
+
+- [ ] **Step 5: Run `npm run check` and `npm run build`**
+
+Expected: green.
+
+- [ ] **Step 6: Manual smoke**
+
+`npm run tauri dev` with a Foundry world running and `vtmtools-bridge@0.6.0`:
+
+- ✅ Pull button visible when Foundry connected; disappears on disconnect.
+- ✅ Click pull → "Imported X new (Y updated, Z skipped) from <world>" toast appears.
+- ✅ New rows show "FVTT · <world>" source chip + their kind chip.
+- ✅ Click pull again → same rows now show as "updated" in the toast count.
+- ✅ Create an `Iron Gullet` merit locally (custom). Pull from a world containing `Iron Gullet`. Result: a new row `Iron Gullet (FVTT — <world>)` appears alongside the local one.
+- ✅ Tri-state filter: clicking "Imported" hides corebook + local rows; clicking "Local" hides corebook + imported; "Corebook" hides custom (both flavors).
+- ✅ The existing Edit button on an imported row works (GM can curate imports).
+
+- [ ] **Step 7: Commit**
+
+```
+git add src/tools/AdvantagesManager.svelte \
+        src/lib/components/AdvantageCard.svelte
+git commit -m "$(cat <<'EOF'
+AdvantagesManager: Pull button + source chip + tri-state filter
+
+Closes the visible half of Library Sync:
+  • "⇣ Pull from world" button (Foundry-connected) drives subscribe
+    → wait → import → toast summary → reload.
+  • Per-row source chip on imported rows ("FVTT · <world>").
+  • Tri-state provenance filter (Corebook / Local / Imported)
+    composes with the existing tag, kind, and search filters.
+
+Auto-suffix dedup (#16 decision): same-name + same-world → update
+in place; same-name + different-world → "<name> (FVTT — <world>)".
+
+Closes #14 #15 #16.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 7: ARCHITECTURE.md §4 updates
+
+**Goal:** Document the three new Tauri commands.
+
+**Files:**
+- Modify: `ARCHITECTURE.md`
+
+**Depends on:** Task 6
+
+**Tests required:** NO
+
+- [ ] **Step 1: Update IPC inventory**
+
+In `ARCHITECTURE.md` §4:
+
+- `src-tauri/src/db/advantage.rs`: append `import_advantages_from_world`; bump count from 5 to 6.
+- `src-tauri/src/bridge/commands.rs`: append `bridge_subscribe`, `bridge_unsubscribe`; bump count from 7 (post-Plan-B) to 9.
+- Running total: 65 → 68.
+
+- [ ] **Step 2: Commit**
+
+```
+git add ARCHITECTURE.md
+git commit -m "$(cat <<'EOF'
+ARCHITECTURE.md: document Plan-C IPC additions
+
+§4 IPC inventory:
+  + db/advantage.rs +1: import_advantages_from_world (5 → 6)
+  + bridge/commands.rs +2: bridge_subscribe, bridge_unsubscribe (7 → 9)
+  + total 65 → 68
+
+Closes #14 #15 #16.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+---
+
+## Task 8: Final verification gate (incl. live-Foundry E2E)
+
+**Goal:** Confirm Phase 4 (Plans A + B + C) end-to-end before the single branch-wide `code-review:code-review`.
+
+- [ ] **Step 1: Run `./scripts/verify.sh`**
+
+Expected: full green.
+
+- [ ] **Step 2: Live-Foundry E2E — full Library Sync round trip**
+
+Boot the Tauri app + a Foundry world with `vtmtools-bridge@0.6.0`.
+
+**Push round trip (#13 — already smoke-tested in Plan B, re-verify):**
+- ✅ Push a corebook merit → appears in Foundry world Items sidebar.
+
+**Pull round trip (#14, #15, #16):**
+- ✅ In Foundry, manually add a few feature items to the world (one of each kind: a Merit, a Flaw, a Background; bonus: a non-feature item like a speciality to verify Skipped outcome).
+- ✅ Click "⇣ Pull from world" in AdvantagesManager. Wait ~2s.
+- ✅ Toast reports "Imported 3 new (1 skipped) from <world>".
+- ✅ New rows appear with kind chips + "FVTT · <world>" source chips.
+- ✅ Click Pull again immediately → "Imported 0 new (3 updated, 1 skipped)".
+- ✅ Modify the Foundry-side description of a merit; pull again → row's description updates in place; the toast shows it as Updated.
+- ✅ Delete an imported row locally via the existing Delete button. Pull again → re-inserts.
+- ✅ Tri-state filter "Imported" shows only the 3 imported rows.
+
+**Cross-world dedup (#16):**
+- ✅ Swap to a different Foundry world (different `world_title`). Add a Merit named the same as an already-imported one. Pull. Result: new row with `(FVTT — <new-world>)` suffix. Both rows visible in the Library; both show source chips with their respective world names.
+
+- [ ] **Step 3: Update plan checkboxes**
+
+Mark every Task 1–7 step as `[x]` in this file. Commit:
+
+```
+git add docs/superpowers/plans/2026-05-14-library-sync-plan-c-pull-attribution-dedup.md
+git commit -m "$(cat <<'EOF'
+Mark Plan C tasks complete
+
+Plan C (pull + attribution + dedup) shipped. Closes #14 #15 #16.
+Milestone 4 (Library Sync) complete.
+
+https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px
+EOF
+)"
+```
+
+- [ ] **Step 4: Single branch-wide code review**
+
+Per CLAUDE.md's lean-execution override, NOW (and not before) invoke `code-review:code-review` against the full Phase 4 branch diff (the union of Plan A + Plan B + Plan C commits). The reviewer agent's report informs any follow-up fix commits before merging.
+
+- [ ] **Step 5: Milestone-close hygiene**
+
+After review-driven fixes (if any) land:
+- Confirm all five milestone-4 issues are closed by the per-plan `Closes #N` commit footers.
+- Confirm the milestone-4 project-board column reflects the closures (auto-handled by GitHub if `Closes #N` footers are present).
+- Plan C is complete. Library Sync (Milestone 4) is complete.


### PR DESCRIPTION
## Summary

Implements Phase 4 Library Sync across three coordinated plans:
- **Plan A:** Foundation schema changes (add `kind` enum column + `source_attribution` for import provenance)
- **Plan B:** Push advantages to Foundry world (new `world.*` umbrella + item subscription)
- **Plan C:** Pull advantages from Foundry world (import with dedup/versioning + source attribution UI)

This PR adds three comprehensive implementation plans as documentation in `docs/superpowers/plans/`, each with detailed task breakdowns, file structure, invariants, and step-by-step execution guidance for subagent-driven development.

## Key Changes

### Documentation (Implementation Plans)

Three new plan documents in `docs/superpowers/plans/`:

1. **`2026-05-14-library-sync-plan-a-library-schema-foundation.md`** (886 lines)
   - Migration `0009_advantages_kind_and_source.sql`: adds `kind` (CHECK-gated enum: merit/flaw/background/boon) and nullable `source_attribution` columns
   - Backfill logic with priority cascade (merit > flaw > background > boon)
   - Extends `Advantage` struct with `kind: AdvantageKind` and `source_attribution: Option<Value>`
   - Updates seed corpus, DB helpers, and UI (kind chip + kind filter)
   - 9 sequential/parallel tasks with test requirements specified per task

2. **`2026-05-14-library-sync-plan-b-push-and-item-subscription.md`** (1674 lines)
   - Foundry module version 0.5.0 → 0.6.0 (additive)
   - **Inbound:** New `item` subscription collection; module hooks `createItem`/`updateItem`/`deleteItem` for world-level items only (filters `parent === null`)
   - **Outbound:** New `world.*` umbrella with `world.create_item` helper; Tauri command `push_advantage_to_world(id)` maps `kind → featuretype` and pushes to active world
   - Adds `FoundryWorldItem` + 3 new `FoundryInbound` variants; `CanonicalWorldItem` canonical shape; `InboundEvent` routing
   - New JS handlers (`item.js`, `world.js`) + Rust builders (`bridge/foundry/actions/world.rs`, `tools/library_push.rs`)
   - 16 tasks with parallel dispatch opportunities; tests required for wire deserialization, translation, and command logic

3. **`2026-05-14-library-sync-plan-c-pull-attribution-dedup.md`** (1138 lines)
   - Consumes Plan B's `item` subscription snapshot
   - New Tauri command `import_advantages_from_world()` reads bridge cache, applies dedup logic, inserts/updates rows
   - Dedup rule: `(name, kind, source_attribution.worldTitle)` triple; collision suffix: `<name> (FVTT — <world>)`
   - Source attribution chip rendering (reuses Phase 1 component)
   - Tri-state filter (corebook / local / imported)
   - 8 tasks; DB helpers + import command + frontend integration

### Architecture & Invariants

All three plans document:
- **File structure:** new files, modified files, explicitly NOT touched (frozen)
- **Dependencies:** Plan A (foundation) → Plan B (push) → Plan C (pull)
- **Invariants:** ARCHITECTURE.md sections cited; error prefixes per §7; IPC inventory updates
- **Tests:** Explicit per-task guidance (YES/NO); TDD on-demand override per CLAUDE.md
- **Lean execution:** One implementer per task; `./scripts/verify.sh` after each commit; single code-review at end

### Key Design Decisions (Locked In)

- **World-level vs. embedded distinction:** Foundry items have `parent` property; subscriber filters `parent === null` to avoid double-counting with actor-enrichment path

https://claude.ai/code/session_01MoVudfzVJh7PSkrS1zR5Px