### PR TITLE
feat(library): Phase 4 Library Sync (push, pull, dedup)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -597,6 +597,8 @@ Rust signature + the types it references in §2) is the stable contract.
   `trigger_foundry_roll`, `post_foundry_chat`.
 - **`src-tauri/src/tools/gm_screen.rs`** (1):
   `gm_screen_push_to_foundry`.
+- **`src-tauri/src/tools/library_push.rs`** (1):
+  `push_advantage_to_world`.
 - **`src-tauri/src/bridge/commands.rs`** (7):
   `bridge_get_characters`, `bridge_get_rolls`,
   `bridge_get_world_items`, `bridge_get_status`, `bridge_refresh`,
@@ -609,7 +611,7 @@ Rust signature + the types it references in §2) is the stable contract.
   snapshots the per-source world-level item caches (Foundry only in
   v1); paired live event is `bridge://foundry/items-updated`.
 
-Total: 64 commands. New commands are registered in
+Total: 65 commands. New commands are registered in
 `src-tauri/src/lib.rs` (`invoke_handler(tauri::generate_handler![...])`).
 See §8 for the Tauri capability / ACL surface.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -600,10 +600,11 @@ Rust signature + the types it references in §2) is the stable contract.
   `gm_screen_push_to_foundry`.
 - **`src-tauri/src/tools/library_push.rs`** (1):
   `push_advantage_to_world`.
-- **`src-tauri/src/bridge/commands.rs`** (7):
+- **`src-tauri/src/bridge/commands.rs`** (9):
   `bridge_get_characters`, `bridge_get_rolls`,
   `bridge_get_world_items`, `bridge_get_status`, `bridge_refresh`,
-  `bridge_set_attribute`, `bridge_get_source_info`.
+  `bridge_set_attribute`, `bridge_get_source_info`,
+  `bridge_subscribe`, `bridge_unsubscribe`.
   Generic across Roll20 and Foundry — `set_attribute`'s `name` is
   opaque to the frontend and translated per-source by the source's
   `BridgeSource` impl. `bridge_get_rolls` snapshots the in-memory
@@ -612,7 +613,7 @@ Rust signature + the types it references in §2) is the stable contract.
   snapshots the per-source world-level item caches (Foundry only in
   v1); paired live event is `bridge://foundry/items-updated`.
 
-Total: 66 commands. New commands are registered in
+Total: 68 commands. New commands are registered in
 `src-tauri/src/lib.rs` (`invoke_handler(tauri::generate_handler![...])`).
 See §8 for the Tauri capability / ACL surface.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -651,6 +651,22 @@ If TLS init fails at startup, the Foundry accept loop is NOT spawned
 in the Foundry browser). The failure is logged once and Foundry stays
 disabled for the session; Roll20 is unaffected.
 
+**Subscription collections (Foundry):** `actors` (auto-subscribed on
+Hello — always-on; preserves pre-Plan-0 behavior), `item` (opt-in via
+`bridge.subscribe { collection: "item" }` — Plan B+ Library Sync
+consumers). The subscription registry lives in
+`vtmtools-bridge/scripts/foundry-actions/bridge.js`; future collections
+(`journal`, `scene`, `chat`, `combat`) are reserved by name in the
+character-tooling roadmap §5 and activated when a consumer feature
+lands.
+
+**Outbound umbrellas (Foundry):** `actor.*` (per-actor edits), `game.*`
+(in-game/table rolls + chat), `storyteller.*` (GM-facing operations
+not tied to a single actor; v1 ships `storyteller.create_world_item`
+only — Library Sync push). See
+`docs/superpowers/specs/2026-04-26-foundry-helper-library-roadmap.md`
+§5 for the per-helper inventory.
+
 ### Tauri events (backend → frontend)
 
 | Event | Payload | Emitted when |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -577,9 +577,10 @@ Rust signature + the types it references in §2) is the stable contract.
   `delete_character_modifier`, `set_modifier_active`,
   `set_modifier_hidden`, `set_modifier_zone`,
   `materialize_advantage_modifier`.
-- **`src-tauri/src/db/advantage.rs`** (5):
+- **`src-tauri/src/db/advantage.rs`** (6):
   `list_advantages`, `add_advantage`, `update_advantage`,
-  `delete_advantage`, `roll_random_advantage`.
+  `delete_advantage`, `roll_random_advantage`,
+  `import_advantages_from_world`.
 - **`src-tauri/src/db/status_template.rs`** (4):
   `list_status_templates`, `add_status_template`,
   `update_status_template`, `delete_status_template`.
@@ -611,7 +612,7 @@ Rust signature + the types it references in §2) is the stable contract.
   snapshots the per-source world-level item caches (Foundry only in
   v1); paired live event is `bridge://foundry/items-updated`.
 
-Total: 65 commands. New commands are registered in
+Total: 66 commands. New commands are registered in
 `src-tauri/src/lib.rs` (`invoke_handler(tauri::generate_handler![...])`).
 See §8 for the Tauri capability / ACL surface.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -597,16 +597,19 @@ Rust signature + the types it references in §2) is the stable contract.
   `trigger_foundry_roll`, `post_foundry_chat`.
 - **`src-tauri/src/tools/gm_screen.rs`** (1):
   `gm_screen_push_to_foundry`.
-- **`src-tauri/src/bridge/commands.rs`** (6):
-  `bridge_get_characters`, `bridge_get_rolls`, `bridge_get_status`,
-  `bridge_refresh`, `bridge_set_attribute`, `bridge_get_source_info`.
+- **`src-tauri/src/bridge/commands.rs`** (7):
+  `bridge_get_characters`, `bridge_get_rolls`,
+  `bridge_get_world_items`, `bridge_get_status`, `bridge_refresh`,
+  `bridge_set_attribute`, `bridge_get_source_info`.
   Generic across Roll20 and Foundry — `set_attribute`'s `name` is
   opaque to the frontend and translated per-source by the source's
   `BridgeSource` impl. `bridge_get_rolls` snapshots the in-memory
   roll-history ring (capacity 200, dedup by `source_id`); see the
-  events table for the paired live event.
+  events table for the paired live event. `bridge_get_world_items`
+  snapshots the per-source world-level item caches (Foundry only in
+  v1); paired live event is `bridge://foundry/items-updated`.
 
-Total: 63 commands. New commands are registered in
+Total: 64 commands. New commands are registered in
 `src-tauri/src/lib.rs` (`invoke_handler(tauri::generate_handler![...])`).
 See §8 for the Tauri capability / ACL surface.
 
@@ -656,6 +659,7 @@ disabled for the session; Roll20 is unaffected.
 | `bridge://foundry/disconnected` | none | Foundry module closes wss connection |
 | `bridge://characters-updated` | `Vec<CanonicalCharacter>` | Any source pushed updated characters; carries the merged cache across all sources |
 | `bridge://roll-received` | `CanonicalRoll` | Foundry source decoded a `roll_result` chat message into a canonical roll; pushed into bridge state ring (capacity 200, dedup by `source_id`) and emitted in one accept-loop arm |
+| `bridge://foundry/items-updated` | `Vec<CanonicalWorldItem>` | Foundry world-level item cache changed (snapshot, upsert, or delete); carries the merged cache flattened across all sources |
 | `modifiers://rows-reaped` | `{ ids: number[] }` | Backend reaped advantage-bound `character_modifiers` rows after a Foundry `deleteItem` hook (via `item_deleted` wire); frontend modifier store drops the listed ids |
 
 ### Svelte cross-tool pub/sub

--- a/docs/superpowers/plans/2026-05-14-library-sync-plan-b-push-and-item-subscription.md
+++ b/docs/superpowers/plans/2026-05-14-library-sync-plan-b-push-and-item-subscription.md
@@ -103,7 +103,7 @@ Tasks 1, 6, 7, 9 are independent (Rust types / JS subscriber / JS handler / Rust
 
 **Tests required:** YES — one deserialize-round-trip test per variant (3 tests).
 
-- [ ] **Step 1: Add `FoundryWorldItem` struct**
+- [x] **Step 1: Add `FoundryWorldItem` struct**
 
 In `src-tauri/src/bridge/foundry/types.rs`, after the existing `FoundryActor` struct (around line 92), add:
 
@@ -132,7 +132,7 @@ pub struct FoundryWorldItem {
 }
 ```
 
-- [ ] **Step 2: Extend `FoundryInbound` enum**
+- [x] **Step 2: Extend `FoundryInbound` enum**
 
 In the existing `pub enum FoundryInbound` block (lines 11-48), add three new variants:
 
@@ -160,7 +160,7 @@ In the existing `pub enum FoundryInbound` block (lines 11-48), add three new var
 
 Note: the existing `ItemDeleted { actor_id, item_id }` variant stays — it's actor-scoped and serves modifier reaping (a different concern). The new `WorldItemDeleted` is world-scoped (no actor_id).
 
-- [ ] **Step 3: Add deserialize tests**
+- [x] **Step 3: Add deserialize tests**
 
 In the existing `#[cfg(test)] mod tests` block (or add one if absent — verify file structure first), add:
 
@@ -216,17 +216,17 @@ fn world_item_deleted_deserializes() {
 
 Wire `type` strings come from `#[serde(tag = "type", rename_all = "snake_case")]` on the enum. The variant names map: `Items → "items"`, `WorldItemUpsert → "world_item_upsert"`, `WorldItemDeleted → "world_item_deleted"`. The JS-side payload must emit these exact strings (Task 6).
 
-- [ ] **Step 4: Run `cargo test`**
+- [x] **Step 4: Run `cargo test`**
 
 Run: `cargo test --manifest-path src-tauri/Cargo.toml bridge::foundry::types`
 
 Expected: 3 new tests pass; no regressions.
 
-- [ ] **Step 5: Run `./scripts/verify.sh`**
+- [x] **Step 5: Run `./scripts/verify.sh`**
 
 Expected: cargo green; downstream code (`bridge/foundry/mod.rs::handle_inbound`) may not yet handle the new variants — that compiles fine as long as `match` is non-exhaustive over `FoundryInbound`. **Verify:** current `mod.rs::handle_inbound` uses an exhaustive match over `FoundryInbound`, so this step WILL fail at cargo check. That's expected — Task 4 fixes it. If verify.sh fails here at `bridge/foundry/mod.rs::handle_inbound`, commit Task 1 with the failure pinned to Task 4, OR roll Tasks 1+4 into the same commit. **Recommended:** dispatch Tasks 1+4 to the same implementer as a single atomic commit since they share an exhaustiveness invariant.
 
-- [ ] **Step 6: Commit (joint with Task 4 — defer)**
+- [x] **Step 6: Commit (joint with Task 4 — defer)**
 
 Hold this commit until Task 4 lands; the joint commit is at Task 4 Step 5.
 
@@ -248,7 +248,7 @@ Hold this commit until Task 4 lands; the joint commit is at Task 4 Step 5.
 
 **Tests required:** NO
 
-- [ ] **Step 1: Add `CanonicalWorldItem` struct**
+- [x] **Step 1: Add `CanonicalWorldItem` struct**
 
 In `src-tauri/src/bridge/types.rs`, after `CanonicalCharacter` (or wherever canonical types live; verify file structure), add:
 
@@ -277,7 +277,7 @@ pub struct CanonicalWorldItem {
 
 Note: the `kind` field here is the Foundry **Item type** ("feature" / "speciality" / "power"), NOT the `AdvantageKind` enum from Plan A (which is the featuretype sub-discriminator for `kind = "feature"` items). They're related but distinct. Plan C's importer maps `(kind == "feature", featuretype) → AdvantageKind`.
 
-- [ ] **Step 2: Mirror in `src/types.ts`**
+- [x] **Step 2: Mirror in `src/types.ts`**
 
 Add to `src/types.ts` (camelCase, matching serde):
 
@@ -297,11 +297,11 @@ export interface CanonicalWorldItem {
 }
 ```
 
-- [ ] **Step 3: Run `./scripts/verify.sh`**
+- [x] **Step 3: Run `./scripts/verify.sh`**
 
 Expected: green on the cargo + TS sides; nothing consumes the new type yet.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```
 git add src-tauri/src/bridge/types.rs src/types.ts
@@ -337,7 +337,7 @@ EOF
 
 **Tests required:** YES — 1 test for `to_canonical_world_item`.
 
-- [ ] **Step 1: Extend `InboundEvent`**
+- [x] **Step 1: Extend `InboundEvent`**
 
 In `src-tauri/src/bridge/source.rs`, add to the existing `InboundEvent` enum:
 
@@ -365,7 +365,7 @@ In `src-tauri/src/bridge/source.rs`, add to the existing `InboundEvent` enum:
     },
 ```
 
-- [ ] **Step 2: Add `to_canonical_world_item` in `translate.rs`**
+- [x] **Step 2: Add `to_canonical_world_item` in `translate.rs`**
 
 In `src-tauri/src/bridge/foundry/translate.rs`, add (or add a new module if translate.rs is actor-only; check the file's current structure first):
 
@@ -384,7 +384,7 @@ pub fn to_canonical_world_item(
 }
 ```
 
-- [ ] **Step 3: Add a test for the translator**
+- [x] **Step 3: Add a test for the translator**
 
 In `translate.rs`'s `#[cfg(test)] mod tests` block (or add one):
 
@@ -407,13 +407,13 @@ fn translate_world_item_preserves_featuretype() {
 }
 ```
 
-- [ ] **Step 4: Run `cargo test` (target translate + source modules)**
+- [x] **Step 4: Run `cargo test` (target translate + source modules)**
 
 Run: `cargo test --manifest-path src-tauri/Cargo.toml bridge::`
 
 Expected: existing tests still pass; new test passes.
 
-- [ ] **Step 5: Commit (atomic with Task 4 — defer)**
+- [x] **Step 5: Commit (atomic with Task 4 — defer)**
 
 Hold this commit until Task 4; combined commit at Task 4 Step 5.
 
@@ -434,7 +434,7 @@ Hold this commit until Task 4; combined commit at Task 4 Step 5.
 
 **Tests required:** YES — 3 tests (one per new variant), pattern matches the existing `actor_deleted_inbound_produces_character_removed_event` test.
 
-- [ ] **Step 1: Add three arms to `handle_inbound`**
+- [x] **Step 1: Add three arms to `handle_inbound`**
 
 In the `match parsed` block of `src-tauri/src/bridge/foundry/mod.rs::handle_inbound`, after the existing `FoundryInbound::ItemDeleted` arm, add:
 
@@ -460,7 +460,7 @@ In the `match parsed` block of `src-tauri/src/bridge/foundry/mod.rs::handle_inbo
             }
 ```
 
-- [ ] **Step 2: Add three tests**
+- [x] **Step 2: Add three tests**
 
 In the existing `#[cfg(test)] mod tests` block of `bridge/foundry/mod.rs`:
 
@@ -516,15 +516,15 @@ async fn world_item_deleted_produces_event() {
 }
 ```
 
-- [ ] **Step 3: Run `./scripts/verify.sh`**
+- [x] **Step 3: Run `./scripts/verify.sh`**
 
 Expected: cargo green. `bridge/mod.rs::accept_loop` may now warn about unhandled `InboundEvent::WorldItem*` variants in the match — Task 5 resolves. If the match is currently exhaustive, the build fails; add `WorldItem* => continue,` placeholders inline as TODOs that Task 5 replaces. **Recommended:** ship Tasks 1+3+4+5 as one implementer commit since they share the inbound-pipeline exhaustiveness invariant.
 
-- [ ] **Step 4: Verify state of dependent files**
+- [x] **Step 4: Verify state of dependent files**
 
 Confirm `bridge/mod.rs::accept_loop` has been pre-prepared (Task 5) OR has placeholder arms. If neither, this task's commit will leave the working tree non-buildable. Coordinate via the joint Task 5 commit.
 
-- [ ] **Step 5: Joint commit (Tasks 1, 3, 4 + minimal Task 5 stub)**
+- [x] **Step 5: Joint commit (Tasks 1, 3, 4 + minimal Task 5 stub)**
 
 ```
 git add src-tauri/src/bridge/foundry/types.rs \
@@ -569,7 +569,7 @@ If Task 5 stubs are added as part of this commit, drop the trailing paragraph fr
 
 **Tests required:** NO — covered by manual smoke (Task 16) plus cargo build (the new Tauri command's compile shape is the gate).
 
-- [ ] **Step 1: Add `world_items` to `BridgeState`**
+- [x] **Step 1: Add `world_items` to `BridgeState`**
 
 In `src-tauri/src/bridge/mod.rs`, find the existing `BridgeState` struct. Add a `world_items` field:
 
@@ -584,7 +584,7 @@ pub world_items: tokio::sync::Mutex<
 
 Update `BridgeState::new()` (or the equivalent constructor) to initialize the new field with an empty HashMap.
 
-- [ ] **Step 2: Add three event arms to `accept_loop`**
+- [x] **Step 2: Add three event arms to `accept_loop`**
 
 In `src-tauri/src/bridge/mod.rs::accept_loop`, in the `match event` block (search for `InboundEvent::CharactersSnapshot`), add three new arms after `InboundEvent::ItemDeleted`:
 
@@ -634,7 +634,7 @@ async fn collect_world_items_snapshot(
 
 The emitted payload is a flat `Vec<CanonicalWorldItem>`; the frontend partitions by source if it needs to (the `source` field on each item carries it).
 
-- [ ] **Step 3: Add `bridge_get_world_items` Tauri command**
+- [x] **Step 3: Add `bridge_get_world_items` Tauri command**
 
 In `src-tauri/src/bridge/commands.rs`, after `bridge_get_rolls`:
 
@@ -653,22 +653,22 @@ pub async fn bridge_get_world_items(
 
 (Adjust the `CanonicalWorldItem` import at the top of the file.)
 
-- [ ] **Step 4: Register the new command**
+- [x] **Step 4: Register the new command**
 
 In `src-tauri/src/lib.rs::invoke_handler!`, append `bridge::commands::bridge_get_world_items` to the command list (next to `bridge_get_rolls`).
 
-- [ ] **Step 5: Update `ARCHITECTURE.md` §4 (same-commit rule)**
+- [x] **Step 5: Update `ARCHITECTURE.md` §4 (same-commit rule)**
 
 CLAUDE.md mandates that any new `#[tauri::command]` lands in the same commit as its ARCH §4 entry. Edit `ARCHITECTURE.md` §4:
 - Append `bridge_get_world_items` to the per-file IPC entry for `bridge/commands.rs`.
 - Bump the running command total: **63 → 64**.
 - Add `bridge://foundry/items-updated` to the events table (this task is where it starts being emitted).
 
-- [ ] **Step 6: Run `./scripts/verify.sh`**
+- [x] **Step 6: Run `./scripts/verify.sh`**
 
 Expected: green.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```
 git add src-tauri/src/bridge/mod.rs \
@@ -711,7 +711,7 @@ EOF
 
 **Tests required:** NO — JS side has no unit-test infrastructure in this repo. Manual smoke against a live Foundry world covers it (Task 16).
 
-- [ ] **Step 1: Create `item.js`**
+- [x] **Step 1: Create `item.js`**
 
 Create `vtmtools-bridge/scripts/foundry-actions/item.js`:
 
@@ -785,7 +785,7 @@ export const itemsSubscriber = {
 };
 ```
 
-- [ ] **Step 2: Register `item` collection in `bridge.js` subscribers map**
+- [x] **Step 2: Register `item` collection in `bridge.js` subscribers map**
 
 In `vtmtools-bridge/scripts/foundry-actions/bridge.js`, add the import and registration:
 
@@ -801,15 +801,15 @@ const subscribers = {
 
 **Collection name:** `item` (singular) matches the spec sketch's `collection: "item"` envelope. The desktop will send `bridge.subscribe { collection: "item" }` to activate it.
 
-- [ ] **Step 3: Manual smoke (deferred to Task 16)**
+- [ ] **Step 3: Manual smoke (deferred to Task 16)** _(this step is itself a deferral — covered by Task 16 Step 2/3)_
 
 Smoke verification is part of Task 16's E2E gate. For this task's verification: confirm `npm run check` (frontend type-check has no opinion on the bridge module — JS module is loaded by Foundry runtime, not by SvelteKit).
 
-- [ ] **Step 4: Run `./scripts/verify.sh`**
+- [x] **Step 4: Run `./scripts/verify.sh`**
 
 Required by CLAUDE.md before every commit, even for JS-only changes. The Rust/TS toolchain pieces of `verify.sh` will no-op on the JS file changes, but a green run confirms nothing else regressed.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```
 git add vtmtools-bridge/scripts/foundry-actions/item.js \
@@ -850,7 +850,7 @@ EOF
 
 **Tests required:** NO (manual smoke covers it in Task 16).
 
-- [ ] **Step 1: Replace the storyteller.js stub**
+- [x] **Step 1: Replace the storyteller.js stub**
 
 Replace the entire contents of `vtmtools-bridge/scripts/foundry-actions/storyteller.js` (currently a 2-line stub) with:
 
@@ -901,15 +901,15 @@ export const handlers = {
 };
 ```
 
-- [ ] **Step 2: Verify `index.js` does not need editing**
+- [x] **Step 2: Verify `index.js` does not need editing**
 
 Confirm via `grep storytellerHandlers vtmtools-bridge/scripts/foundry-actions/index.js` that the import + spread already exist (they should — `storyteller.js` was previously a reserved-umbrella stub already wired in). If a fresh checkout somehow lacks the wiring, restore it; otherwise do nothing.
 
-- [ ] **Step 3: Run `./scripts/verify.sh`**
+- [x] **Step 3: Run `./scripts/verify.sh`**
 
 Required by CLAUDE.md before every commit, even for JS-only changes.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```
 git add vtmtools-bridge/scripts/foundry-actions/storyteller.js
@@ -951,15 +951,15 @@ EOF
 
 **Tests required:** NO
 
-- [ ] **Step 1: Bump version**
+- [x] **Step 1: Bump version**
 
 Change `module.json`'s `"version": "0.5.0"` to `"version": "0.6.0"`.
 
-- [ ] **Step 2: Run `./scripts/verify.sh`**
+- [x] **Step 2: Run `./scripts/verify.sh`**
 
 Required by CLAUDE.md before every commit.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```
 git add vtmtools-bridge/module.json
@@ -1000,7 +1000,7 @@ EOF
 
 **Tests required:** YES — 2 tests (happy path envelope shape + invalid featuretype rejection).
 
-- [ ] **Step 1: Replace the storyteller.rs stub**
+- [x] **Step 1: Replace the storyteller.rs stub**
 
 Replace the entire contents of `src-tauri/src/bridge/foundry/actions/storyteller.rs` (currently a 1-line stub) with:
 
@@ -1067,21 +1067,21 @@ mod tests {
 }
 ```
 
-- [ ] **Step 2: Verify `actions/mod.rs` does not need editing**
+- [x] **Step 2: Verify `actions/mod.rs` does not need editing**
 
 Confirm via `grep 'pub mod storyteller' src-tauri/src/bridge/foundry/actions/mod.rs` that the module declaration already exists (it should — the reserved-umbrella stub was declared previously). If a fresh checkout somehow lacks it, restore it; otherwise do nothing.
 
-- [ ] **Step 3: Run `cargo test`**
+- [x] **Step 3: Run `cargo test`**
 
 Run: `cargo test --manifest-path src-tauri/Cargo.toml bridge::foundry::actions::storyteller`
 
 Expected: 2 tests pass.
 
-- [ ] **Step 4: Run `./scripts/verify.sh`**
+- [x] **Step 4: Run `./scripts/verify.sh`**
 
 Required by CLAUDE.md before every commit.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```
 git add src-tauri/src/bridge/foundry/actions/storyteller.rs
@@ -1121,7 +1121,7 @@ EOF
 
 **Tests required:** YES — 1 happy-path test using an in-memory pool + a faked outbound channel via a temporary `BridgeState` that captures sent messages.
 
-- [ ] **Step 1: Create `library_push.rs`**
+- [x] **Step 1: Create `library_push.rs`**
 
 Create `src-tauri/src/tools/library_push.rs`:
 
@@ -1204,13 +1204,13 @@ mod tests {
 
 **Implementation note on `__internal_db_list`:** the existing `db::advantage::db_list` is private to the module. Promote it to `pub(crate)` (rename optional — `db_list` is fine for the crate-internal name) so `tools/library_push` can read advantages without going through Tauri state from a Tauri command. Update `db/advantage.rs` to add `pub(crate)` to the function signature.
 
-- [ ] **Step 2: Promote `db_list` to `pub(crate)`**
+- [x] **Step 2: Promote `db_list` to `pub(crate)`**
 
 In `src-tauri/src/db/advantage.rs`, change `async fn db_list(...)` to `pub(crate) async fn db_list(...)`. Use this from `library_push.rs` directly: `crate::db::advantage::db_list(&db.0).await`.
 
 Drop the `__internal_db_list` rename in the snippet above; just use `db_list`.
 
-- [ ] **Step 3: Register the module**
+- [x] **Step 3: Register the module**
 
 In `src-tauri/src/tools/mod.rs`:
 
@@ -1219,7 +1219,7 @@ pub mod library_push;
 // (alongside existing pub mod entries)
 ```
 
-- [ ] **Step 4: Add unit test**
+- [x] **Step 4: Add unit test**
 
 In `library_push.rs::tests`:
 
@@ -1264,23 +1264,23 @@ mod tests {
 
 Full integration (DB → builder → outbound channel) is covered by Task 16's manual E2E smoke. Unit tests cover the two pure helpers.
 
-- [ ] **Step 5: Run `cargo test`**
+- [x] **Step 5: Run `cargo test`**
 
 Run: `cargo test --manifest-path src-tauri/Cargo.toml tools::library_push`
 
 Expected: 4 tests pass.
 
-- [ ] **Step 6: Update `ARCHITECTURE.md` §4 (same-commit rule)**
+- [x] **Step 6: Update `ARCHITECTURE.md` §4 (same-commit rule)**
 
 CLAUDE.md mandates that any new `#[tauri::command]` lands in the same commit as its ARCH §4 entry. Edit `ARCHITECTURE.md` §4:
 - Add a new per-file entry for `tools/library_push.rs` listing `push_advantage_to_world`.
 - Bump the running command total: **64 → 65**.
 
-- [ ] **Step 7: Run `./scripts/verify.sh`**
+- [x] **Step 7: Run `./scripts/verify.sh`**
 
 Expected: green.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```
 git add src-tauri/src/tools/library_push.rs \
@@ -1324,7 +1324,7 @@ EOF
 
 **Tests required:** NO
 
-- [ ] **Step 1: Add to `invoke_handler!`**
+- [x] **Step 1: Add to `invoke_handler!`**
 
 In `src-tauri/src/lib.rs`, in the `generate_handler![...]` list, add:
 
@@ -1334,11 +1334,11 @@ tools::library_push::push_advantage_to_world,
 
 near the other `tools::` entries (e.g., next to `tools::foundry_chat::*`).
 
-- [ ] **Step 2: Run `./scripts/verify.sh`**
+- [x] **Step 2: Run `./scripts/verify.sh`**
 
 Expected: green.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```
 git add src-tauri/src/lib.rs
@@ -1374,7 +1374,7 @@ EOF
 
 **Tests required:** NO
 
-- [ ] **Step 1: Create `src/lib/library/api.ts`**
+- [x] **Step 1: Create `src/lib/library/api.ts`**
 
 ```ts
 import { invoke } from '@tauri-apps/api/core';
@@ -1393,15 +1393,15 @@ export function pushAdvantageToWorld(id: number): Promise<void> {
 }
 ```
 
-- [ ] **Step 2: Run `npm run check`**
+- [x] **Step 2: Run `npm run check`**
 
 Expected: green.
 
-- [ ] **Step 3: Run `./scripts/verify.sh`**
+- [x] **Step 3: Run `./scripts/verify.sh`**
 
 Required by CLAUDE.md before every commit. `npm run check` alone is not the gate — `verify.sh` also runs `cargo check`, `cargo test`, and the frontend build.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```
 git add src/lib/library/api.ts
@@ -1435,17 +1435,17 @@ EOF
 
 **Tests required:** NO
 
-- [ ] **Step 1: Read current `bridge.svelte.ts` structure**
+- [x] **Step 1: Read current `bridge.svelte.ts` structure**
 
 Locate the existing characters-updated subscription. The pattern: on mount, call `invoke('bridge_get_characters')`; subscribe to `bridge://characters-updated` and replace `characters` state on each emit.
 
-- [ ] **Step 2: Add `worldItems` state and subscription**
+- [x] **Step 2: Add `worldItems` state and subscription**
 
 Add `let worldItems: CanonicalWorldItem[] = $state([])` and an `unlisten` for `bridge://foundry/items-updated`. Hydrate on init via a wrapper call. Use the same lifecycle pattern as `characters` — the goal is a drop-in mirror.
 
 If the store has a single `init()` that registers all subscriptions, append the items-updated listener there. If it's per-piece-of-state, copy the characters pattern verbatim with `worldItems` substituted.
 
-- [ ] **Step 3: Add a typed wrapper for `bridge_get_world_items`**
+- [x] **Step 3: Add a typed wrapper for `bridge_get_world_items`**
 
 In `src/lib/bridge/api.ts` (or wherever existing `bridge_*` wrappers live):
 
@@ -1455,15 +1455,15 @@ export function bridgeGetWorldItems(): Promise<CanonicalWorldItem[]> {
 }
 ```
 
-- [ ] **Step 4: Run `npm run check` and `npm run build`**
+- [x] **Step 4: Run `npm run check` and `npm run build`**
 
 Expected: green.
 
-- [ ] **Step 5: Run `./scripts/verify.sh`**
+- [x] **Step 5: Run `./scripts/verify.sh`**
 
 Required by CLAUDE.md before every commit. The npm steps above are a tighter inner loop; `verify.sh` is the full gate.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```
 git add src/store/bridge.svelte.ts src/lib/bridge/api.ts
@@ -1499,11 +1499,11 @@ EOF
 
 **Tests required:** NO (manual smoke covers it).
 
-- [ ] **Step 1: Find the per-row action surface**
+- [x] **Step 1: Find the per-row action surface**
 
 Locate where each row's actions render (probably in `AdvantageCard.svelte`'s footer). The existing "Edit" and "Delete" buttons live there.
 
-- [ ] **Step 2: Add "Push to world" button**
+- [x] **Step 2: Add "Push to world" button**
 
 Add a button next to Edit/Delete:
 
@@ -1542,11 +1542,11 @@ The `bridgeStore.status.foundry` predicate gates visibility — disconnected ses
 
 CSS — reuse the existing row-action button styling. No new tokens.
 
-- [ ] **Step 3: Run `npm run check` and `npm run build`**
+- [x] **Step 3: Run `npm run check` and `npm run build`**
 
 Expected: green.
 
-- [ ] **Step 4: Manual smoke**
+- [ ] **Step 4: Manual smoke** _(deferred to user — requires interactive `npm run tauri dev` + live Foundry world)_
 
 `npm run tauri dev` with a Foundry world running and the bridge connected:
 
@@ -1556,11 +1556,11 @@ Expected: green.
 - ✅ Disconnect Foundry → push buttons disappear (or grey out, depending on the reactive guard).
 - ✅ Push a custom Boon → world Item appears with featuretype = boon.
 
-- [ ] **Step 5: Run `./scripts/verify.sh`**
+- [x] **Step 5: Run `./scripts/verify.sh`**
 
 Required by CLAUDE.md before every commit.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```
 git add src/tools/AdvantagesManager.svelte \
@@ -1596,7 +1596,7 @@ EOF
 
 **Tests required:** NO
 
-- [ ] **Step 1: Update Bridge WebSocket protocol section**
+- [x] **Step 1: Update Bridge WebSocket protocol section**
 
 In §4 Bridge WebSocket protocol, after the existing message-framing paragraph, add a paragraph on the `item` subscription and `storyteller.*` umbrella:
 
@@ -1604,11 +1604,11 @@ In §4 Bridge WebSocket protocol, after the existing message-framing paragraph, 
 >
 > **Outbound umbrellas (Foundry):** `actor.*` (per-actor edits), `game.*` (in-game/table rolls + chat), `storyteller.*` (GM-facing operations not tied to a single actor; v1 ships `storyteller.create_world_item` only — Library Sync push). See `docs/superpowers/specs/2026-04-26-foundry-helper-library-roadmap.md` §5 for the per-helper inventory.
 
-- [ ] **Step 2: Run `./scripts/verify.sh`**
+- [x] **Step 2: Run `./scripts/verify.sh`**
 
 Expected: green.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```
 git add ARCHITECTURE.md
@@ -1636,11 +1636,11 @@ EOF
 
 **Goal:** Confirm Plan B end-to-end against a live Foundry world before handing off to Plan C.
 
-- [ ] **Step 1: Run `./scripts/verify.sh`**
+- [x] **Step 1: Run `./scripts/verify.sh`**
 
 Expected: full green.
 
-- [ ] **Step 2: Live-Foundry smoke — push side (#13)**
+- [ ] **Step 2: Live-Foundry smoke — push side (#13)** _(deferred to user — requires interactive `npm run tauri dev` + live Foundry world with vtmtools-bridge@0.6.0)_
 
 Boot the Tauri app + a Foundry world with `vtmtools-bridge@0.6.0` installed.
 
@@ -1650,7 +1650,7 @@ Boot the Tauri app + a Foundry world with `vtmtools-bridge@0.6.0` installed.
 - ✅ Click push on "Prey Exclusion" flaw → same path, featuretype=Flaw.
 - ✅ Push a custom row with kind=Boon → appears as featuretype=Boon.
 
-- [ ] **Step 3: Live-Foundry smoke — subscription side (#27)**
+- [ ] **Step 3: Live-Foundry smoke — subscription side (#27)** _(deferred to user — naturally covered by Plan C's importer flow if manual triggering proves unreachable)_
 
 (Without Plan C's import UI, the desktop never sends `bridge.subscribe { item }` automatically. Test by manually triggering subscription from the JS console of the Foundry browser session OR by waiting for Plan C.)
 
@@ -1667,7 +1667,7 @@ const ws = game.modules.get("vtmtools-bridge")?._socket;
 
 If manual triggering proves unreachable, mark this smoke as **DEFER TO PLAN C** in the verification log — Plan C's importer flow tests the subscription end-to-end naturally.
 
-- [ ] **Step 4: Update plan checkboxes**
+- [x] **Step 4: Update plan checkboxes**
 
 Mark every Task 1–15 step as `[x]` in this file. Commit:
 

--- a/docs/superpowers/plans/2026-05-14-library-sync-plan-c-pull-attribution-dedup.md
+++ b/docs/superpowers/plans/2026-05-14-library-sync-plan-c-pull-attribution-dedup.md
@@ -1195,7 +1195,7 @@ EOF
 )"
 ```
 
-- [ ] **Step 4: Single branch-wide code review** _(pending — running immediately after this checkbox commit)_
+- [x] **Step 4: Single branch-wide code review** _(ran 2026-05-17; found 1 high-confidence bug — `update_advantage` wiped `source_attribution` on imported-row edits — fixed in a follow-up commit with a regression test)_
 
 Per CLAUDE.md's lean-execution override, NOW (and not before) invoke `code-review:code-review` against the full Phase 4 branch diff (the union of Plan A + Plan B + Plan C commits). The reviewer agent's report informs any follow-up fix commits before merging.
 

--- a/docs/superpowers/plans/2026-05-14-library-sync-plan-c-pull-attribution-dedup.md
+++ b/docs/superpowers/plans/2026-05-14-library-sync-plan-c-pull-attribution-dedup.md
@@ -95,7 +95,7 @@ Tasks 1 and 3 are independent and can dispatch in parallel. Task 2 depends on Ta
 
 **Tests required:** YES — 6 tests minimum (one per dedup branch + the re-pull-of-secondary-world regression case).
 
-- [ ] **Step 1: Add `db_find_by_foundry_id`**
+- [x] **Step 1: Add `db_find_by_foundry_id`**
 
 Primary identity lookup, keyed on the immutable Foundry document id (carried via `source_attribution.foundryId`) scoped by world title. This is the lookup that makes re-pulls idempotent regardless of name suffixing.
 
@@ -144,7 +144,7 @@ pub(crate) async fn db_find_by_foundry_id(
 }
 ```
 
-- [ ] **Step 2: Add `db_collides_locally`**
+- [x] **Step 2: Add `db_collides_locally`**
 
 Helper that detects collision against any row with the same name+kind regardless of attribution (for the suffix path):
 
@@ -166,7 +166,7 @@ pub(crate) async fn db_collides_locally(
 }
 ```
 
-- [ ] **Step 3: Add the `ImportOutcome` enum + `db_upsert_imported`**
+- [x] **Step 3: Add the `ImportOutcome` enum + `db_upsert_imported`**
 
 Add to `shared/types.rs` (since it crosses the IPC boundary):
 
@@ -286,7 +286,7 @@ pub(crate) async fn db_upsert_imported(
 }
 ```
 
-- [ ] **Step 4: Tests**
+- [x] **Step 4: Tests**
 
 In the existing `#[cfg(test)] mod tests` block:
 
@@ -416,17 +416,17 @@ async fn find_by_foundry_id_returns_none_for_local_row() {
 }
 ```
 
-- [ ] **Step 5: Run `cargo test`**
+- [x] **Step 5: Run `cargo test`**
 
 Run: `cargo test --manifest-path src-tauri/Cargo.toml db::advantage`
 
 Expected: all existing tests + 6 new tests pass.
 
-- [ ] **Step 6: Run `./scripts/verify.sh`**
+- [x] **Step 6: Run `./scripts/verify.sh`**
 
 Expected: green.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```
 git add src-tauri/src/db/advantage.rs src-tauri/src/shared/types.rs
@@ -473,7 +473,7 @@ EOF
 
 **Tests required:** YES — 1 integration test that constructs an in-memory `BridgeState` with a faked `world_items` cache and asserts the outcome list.
 
-- [ ] **Step 1: Add the Tauri command**
+- [x] **Step 1: Add the Tauri command**
 
 In `src-tauri/src/db/advantage.rs`:
 
@@ -600,7 +600,7 @@ use crate::shared::types::{Field, FieldValue, NumberFieldValue};
 
 (`chrono` is in `Cargo.toml` already — verify; if not, this is a YAGNI win — use `std::time::SystemTime` + manual ISO-8601 formatting via existing helpers.)
 
-- [ ] **Step 2: Integration test**
+- [x] **Step 2: Integration test**
 
 ```rust
 #[tokio::test]
@@ -635,21 +635,21 @@ async fn import_from_world_filters_non_feature_and_unknown_featuretype() {
 
 **Implementation note:** if `BridgeConn` lacks test-fixture support, mark this test `#[ignore]` with a comment pointing to Task 8's E2E smoke, OR refactor `import_advantages_from_world` to take an injectable items-source — both are fine. The 5 unit tests on `db_upsert_imported` (Task 1) carry the dedup logic correctness; this integration test would only cover the filter+orchestration shell.
 
-- [ ] **Step 3: Run `cargo test`**
+- [x] **Step 3: Run `cargo test`**
 
 Expected: existing tests still pass; new integration test passes OR is marked `#[ignore]` with rationale.
 
-- [ ] **Step 4: Update `ARCHITECTURE.md` §4 (same-commit rule)**
+- [x] **Step 4: Update `ARCHITECTURE.md` §4 (same-commit rule)**
 
 CLAUDE.md mandates that any new `#[tauri::command]` lands in the same commit as its ARCH §4 entry. Edit `ARCHITECTURE.md` §4:
 - Append `import_advantages_from_world` to the per-file IPC entry for `db/advantage.rs`.
 - Bump the running command total: **65 → 66**.
 
-- [ ] **Step 5: Run `./scripts/verify.sh`**
+- [x] **Step 5: Run `./scripts/verify.sh`**
 
 Expected: green.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```
 git add src-tauri/src/db/advantage.rs ARCHITECTURE.md
@@ -692,7 +692,7 @@ EOF
 
 **Tests required:** NO — composes existing primitives; manual smoke in Task 8.
 
-- [ ] **Step 1: Add the commands**
+- [x] **Step 1: Add the commands**
 
 In `src-tauri/src/bridge/commands.rs`:
 
@@ -736,17 +736,17 @@ pub async fn bridge_unsubscribe(
 }
 ```
 
-- [ ] **Step 2: Update `ARCHITECTURE.md` §4 (same-commit rule)**
+- [x] **Step 2: Update `ARCHITECTURE.md` §4 (same-commit rule)**
 
 CLAUDE.md mandates that any new `#[tauri::command]` lands in the same commit as its ARCH §4 entry. Edit `ARCHITECTURE.md` §4:
 - Append `bridge_subscribe` and `bridge_unsubscribe` to the per-file IPC entry for `bridge/commands.rs`.
 - Bump the running command total: **66 → 68**.
 
-- [ ] **Step 3: Run `./scripts/verify.sh`**
+- [x] **Step 3: Run `./scripts/verify.sh`**
 
 Expected: green.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```
 git add src-tauri/src/bridge/commands.rs ARCHITECTURE.md
@@ -780,7 +780,7 @@ EOF
 
 **Tests required:** NO
 
-- [ ] **Step 1: Add three lines**
+- [x] **Step 1: Add three lines**
 
 In `invoke_handler!`:
 
@@ -792,11 +792,11 @@ bridge::commands::bridge_unsubscribe,
 
 (Cluster `import_advantages_from_world` near `db::advantage::*`; cluster the `bridge_*` ones near other `bridge::commands::*` entries.)
 
-- [ ] **Step 2: Run `./scripts/verify.sh`**
+- [x] **Step 2: Run `./scripts/verify.sh`**
 
 Expected: green.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```
 git add src-tauri/src/lib.rs
@@ -835,7 +835,7 @@ EOF
 
 **Tests required:** NO required, but if the repo has vitest set up, add 2-3 tests for the pure `importer.ts` helpers.
 
-- [ ] **Step 1: Add `ImportOutcome` to `src/types.ts`**
+- [x] **Step 1: Add `ImportOutcome` to `src/types.ts`**
 
 ```ts
 export type AdvantageKind = 'merit' | 'flaw' | 'background' | 'boon';
@@ -848,7 +848,7 @@ export type ImportOutcome =
 
 (Verify `AdvantageKind` is already in `src/types.ts` from Plan A — should be.)
 
-- [ ] **Step 2: Extend `src/lib/library/api.ts`**
+- [x] **Step 2: Extend `src/lib/library/api.ts`**
 
 ```ts
 import { invoke } from '@tauri-apps/api/core';
@@ -875,7 +875,7 @@ export function unsubscribeFromWorldItems(): Promise<void> {
 
 **SourceKind serialization note:** Rust's `SourceKind` enum serializes as `"foundry"` / `"roll20"` (snake_case). Verify by inspecting `src-tauri/src/bridge/types.rs` for the serde attribute on `SourceKind` (around line 5).
 
-- [ ] **Step 3: Create `src/lib/library/importer.ts`**
+- [x] **Step 3: Create `src/lib/library/importer.ts`**
 
 ```ts
 import type { ImportOutcome } from '../../types';
@@ -917,15 +917,15 @@ export function summaryAsToast(summary: ImportSummary, worldTitle: string): stri
 }
 ```
 
-- [ ] **Step 4: Run `npm run check`**
+- [x] **Step 4: Run `npm run check`**
 
 Expected: green.
 
-- [ ] **Step 5: Run `./scripts/verify.sh`**
+- [x] **Step 5: Run `./scripts/verify.sh`**
 
 Required by CLAUDE.md before every commit. The npm check above is a fast inner-loop signal; `verify.sh` is the gate.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```
 git add src/lib/library/api.ts src/lib/library/importer.ts src/types.ts
@@ -970,7 +970,7 @@ EOF
 
 **Tests required:** NO (UI; manual smoke covers it).
 
-- [ ] **Step 1: Verify `SourceAttributionChip.svelte`**
+- [x] **Step 1: Verify `SourceAttributionChip.svelte`**
 
 Read `src/lib/components/SourceAttributionChip.svelte`. The actual prop names are `source: SourceKind` and `worldTitle?: string | null` — pass `<SourceAttributionChip source="foundry" worldTitle={adv.sourceAttribution?.worldTitle} />`. (The earlier sketch using `world=` was wrong — Svelte silently drops unknown props and `npm run check` will surface the TS error.) If the prop shape ever changes, the import-version chip can be inline:
 
@@ -982,7 +982,7 @@ Read `src/lib/components/SourceAttributionChip.svelte`. The actual prop names ar
 {/if}
 ```
 
-- [ ] **Step 2: Add the "Pull from active world" button**
+- [x] **Step 2: Add the "Pull from active world" button**
 
 In `AdvantagesManager.svelte`'s toolbar area (near the existing Sort/Filter controls):
 
@@ -1040,7 +1040,7 @@ In `AdvantagesManager.svelte`'s toolbar area (near the existing Sort/Filter cont
 
 (Adapt `bridgeStore` accessors to match Plan B's actual exports.)
 
-- [ ] **Step 3: Add source chip on rows**
+- [x] **Step 3: Add source chip on rows**
 
 In `src/lib/components/AdvantageCard.svelte`, near the kind chip from Plan A:
 
@@ -1061,7 +1061,7 @@ CSS:
 }
 ```
 
-- [ ] **Step 4: Add tri-state filter**
+- [x] **Step 4: Add tri-state filter**
 
 Extend `AdvantagesManager.svelte`'s state:
 
@@ -1089,11 +1089,11 @@ const visible = $derived(
 
 Render a small chip row with 4 buttons (`All / Corebook / Local / Imported`) using the same chip styling as tags. Mutually exclusive — clicking one sets it as `provenanceFilter`.
 
-- [ ] **Step 5: Run `npm run check` and `npm run build`**
+- [x] **Step 5: Run `npm run check` and `npm run build`**
 
 Expected: green.
 
-- [ ] **Step 6: Manual smoke**
+- [ ] **Step 6: Manual smoke** _(deferred to user — requires interactive `npm run tauri dev` + live Foundry world with vtmtools-bridge@0.6.0)_
 
 `npm run tauri dev` with a Foundry world running and `vtmtools-bridge@0.6.0`:
 
@@ -1106,11 +1106,11 @@ Expected: green.
 - ✅ The existing Edit button on an imported row works (GM can curate imports).
 - ✅ **Re-pull regression check** (Plan C Task 1's foundryId-keyed dedup): create the suffixed `Iron Gullet (FVTT — <world>)` row above, then click Pull again. The suffixed row count must stay at 1 (Updated, not Inserted-duplicate).
 
-- [ ] **Step 7: Run `./scripts/verify.sh`**
+- [x] **Step 7: Run `./scripts/verify.sh`**
 
 Required by CLAUDE.md before every commit.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```
 git add src/tools/AdvantagesManager.svelte \
@@ -1154,11 +1154,11 @@ The task overview table's row for Task 7 stays as a numbered placeholder for rea
 
 **Goal:** Confirm Phase 4 (Plans A + B + C) end-to-end before the single branch-wide `code-review:code-review`.
 
-- [ ] **Step 1: Run `./scripts/verify.sh`**
+- [x] **Step 1: Run `./scripts/verify.sh`**
 
 Expected: full green.
 
-- [ ] **Step 2: Live-Foundry E2E — full Library Sync round trip**
+- [ ] **Step 2: Live-Foundry E2E — full Library Sync round trip** _(deferred to user — requires interactive Tauri dev + Foundry world running vtmtools-bridge@0.6.0)_
 
 Boot the Tauri app + a Foundry world with `vtmtools-bridge@0.6.0`.
 
@@ -1178,7 +1178,7 @@ Boot the Tauri app + a Foundry world with `vtmtools-bridge@0.6.0`.
 **Cross-world dedup (#16):**
 - ✅ Swap to a different Foundry world (different `world_title`). Add a Merit named the same as an already-imported one. Pull. Result: new row with `(FVTT — <new-world>)` suffix. Both rows visible in the Library; both show source chips with their respective world names.
 
-- [ ] **Step 3: Update plan checkboxes**
+- [x] **Step 3: Update plan checkboxes**
 
 Mark every Task 1–7 step as `[x]` in this file. Commit:
 
@@ -1195,11 +1195,11 @@ EOF
 )"
 ```
 
-- [ ] **Step 4: Single branch-wide code review**
+- [ ] **Step 4: Single branch-wide code review** _(pending — running immediately after this checkbox commit)_
 
 Per CLAUDE.md's lean-execution override, NOW (and not before) invoke `code-review:code-review` against the full Phase 4 branch diff (the union of Plan A + Plan B + Plan C commits). The reviewer agent's report informs any follow-up fix commits before merging.
 
-- [ ] **Step 5: Milestone-close hygiene**
+- [ ] **Step 5: Milestone-close hygiene** _(deferred to user — confirms `Closes #N` footer-driven issue closures via PR / merge to master)_
 
 After review-driven fixes (if any) land:
 - Confirm all five milestone-4 issues are closed by the per-plan `Closes #N` commit footers.

--- a/src-tauri/src/bridge/commands.rs
+++ b/src-tauri/src/bridge/commands.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 
 use tauri::State;
 
-use crate::bridge::types::{CanonicalCharacter, CanonicalRoll, SourceInfo, SourceKind};
+use crate::bridge::types::{
+    CanonicalCharacter, CanonicalRoll, CanonicalWorldItem, SourceInfo, SourceKind,
+};
 use crate::bridge::BridgeConn;
 use crate::bridge::BridgeState;
 
@@ -37,6 +39,17 @@ pub async fn bridge_get_rolls(
     conn: State<'_, BridgeConn>,
 ) -> Result<Vec<CanonicalRoll>, String> {
     Ok(conn.0.get_rolls().await)
+}
+
+/// Returns every world-level item known across every source. Used by
+/// the frontend on initial load; live updates flow through the
+/// `bridge://foundry/items-updated` event.
+#[tauri::command]
+pub async fn bridge_get_world_items(
+    conn: State<'_, BridgeConn>,
+) -> Result<Vec<CanonicalWorldItem>, String> {
+    let store = conn.0.world_items.lock().await;
+    Ok(store.values().flat_map(|m| m.values().cloned()).collect())
 }
 
 /// Inner logic shared by the Tauri command and any non-IPC caller (the new

--- a/src-tauri/src/bridge/commands.rs
+++ b/src-tauri/src/bridge/commands.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use tauri::State;
 
+use crate::bridge::foundry::actions::bridge as bridge_actions;
 use crate::bridge::types::{
     CanonicalCharacter, CanonicalRoll, CanonicalWorldItem, SourceInfo, SourceKind,
 };
@@ -145,4 +146,46 @@ pub async fn bridge_get_source_info(
 ) -> Result<Option<SourceInfo>, String> {
     let info = conn.0.source_info.lock().await;
     Ok(info.get(&source).cloned())
+}
+
+/// Send `bridge.subscribe { collection }` to the named source. No-op
+/// if the source isn't connected. Per-source dispatch: in v1 only
+/// Foundry implements bridge.* subscriptions; Roll20 returns an error
+/// string rather than silently ignoring — gives the frontend a clearer
+/// signal.
+#[tauri::command]
+pub async fn bridge_subscribe(
+    conn: State<'_, BridgeConn>,
+    source: SourceKind,
+    collection: String,
+) -> Result<(), String> {
+    if source != SourceKind::Foundry {
+        return Err(format!(
+            "bridge/subscribe: source {source:?} does not support subscriptions"
+        ));
+    }
+    let payload = bridge_actions::build_subscribe(&collection);
+    let text = serde_json::to_string(&payload)
+        .map_err(|e| format!("bridge/subscribe: serialize: {e}"))?;
+    send_to_source_inner(&conn.0, source, text).await
+}
+
+/// Send `bridge.unsubscribe { collection }` to the named source. No-op
+/// if the source isn't connected. v1 only Foundry implements bridge.*
+/// subscriptions; Roll20 returns an error string.
+#[tauri::command]
+pub async fn bridge_unsubscribe(
+    conn: State<'_, BridgeConn>,
+    source: SourceKind,
+    collection: String,
+) -> Result<(), String> {
+    if source != SourceKind::Foundry {
+        return Err(format!(
+            "bridge/unsubscribe: source {source:?} does not support subscriptions"
+        ));
+    }
+    let payload = bridge_actions::build_unsubscribe(&collection);
+    let text = serde_json::to_string(&payload)
+        .map_err(|e| format!("bridge/unsubscribe: serialize: {e}"))?;
+    send_to_source_inner(&conn.0, source, text).await
 }

--- a/src-tauri/src/bridge/foundry/actions/storyteller.rs
+++ b/src-tauri/src/bridge/foundry/actions/storyteller.rs
@@ -1,1 +1,60 @@
-// Foundry storyteller.* helper builders. Reserved umbrella; no helpers in v1.
+//! Foundry `storyteller.*` helper builders. World-level operations not tied
+//! to a single actor.
+//!
+//! v1 milestone-4 ships exactly one helper: `storyteller.create_world_item` —
+//! creates a Foundry-world-level Item doc (feature type) with the
+//! given featuretype (merit / flaw / background / boon).
+
+use serde_json::{json, Value};
+
+/// Build a `storyteller.create_world_item { name, featuretype, description, points }`
+/// envelope. Validates featuretype against the same enum
+/// `actor.create_feature` uses.
+pub fn build_create_world_item(
+    name: &str,
+    featuretype: &str,
+    description: &str,
+    points: i32,
+) -> Result<Value, String> {
+    match featuretype {
+        "merit" | "flaw" | "background" | "boon" => {}
+        other => {
+            return Err(format!(
+                "foundry/storyteller.create_world_item: invalid featuretype: {other}"
+            ));
+        }
+    }
+    Ok(json!({
+        "type": "storyteller.create_world_item",
+        "name": name,
+        "featuretype": featuretype,
+        "description": description,
+        "points": points,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_world_item_envelope_shape() {
+        let out = build_create_world_item("Iron Gullet", "merit", "rancid blood ok", 3)
+            .expect("merit is a valid featuretype");
+        assert_eq!(out["type"], "storyteller.create_world_item");
+        assert_eq!(out["name"], "Iron Gullet");
+        assert_eq!(out["featuretype"], "merit");
+        assert_eq!(out["description"], "rancid blood ok");
+        assert_eq!(out["points"], 3);
+    }
+
+    #[test]
+    fn create_world_item_invalid_featuretype_returns_err() {
+        let err = build_create_world_item("X", "discipline", "", 0)
+            .expect_err("discipline is not a valid featuretype");
+        assert!(
+            err.starts_with("foundry/storyteller.create_world_item: invalid featuretype:"),
+            "got: {err}"
+        );
+    }
+}

--- a/src-tauri/src/bridge/foundry/mod.rs
+++ b/src-tauri/src/bridge/foundry/mod.rs
@@ -50,6 +50,25 @@ impl BridgeSource for FoundrySource {
                     item_id,
                 }])
             }
+            FoundryInbound::Items { items } => {
+                let canonical: Vec<_> = items.iter().map(translate::to_canonical_world_item).collect();
+                Ok(vec![InboundEvent::WorldItemsSnapshot {
+                    source: crate::bridge::types::SourceKind::Foundry,
+                    items: canonical,
+                }])
+            }
+            FoundryInbound::WorldItemUpsert { item } => {
+                Ok(vec![InboundEvent::WorldItemUpsert {
+                    source: crate::bridge::types::SourceKind::Foundry,
+                    item: translate::to_canonical_world_item(&item),
+                }])
+            }
+            FoundryInbound::WorldItemDeleted { item_id } => {
+                Ok(vec![InboundEvent::WorldItemDeleted {
+                    source: crate::bridge::types::SourceKind::Foundry,
+                    item_id,
+                }])
+            }
         }
     }
 
@@ -140,6 +159,56 @@ mod tests {
                 assert_eq!(item_id, "merit-1");
             }
             other => panic!("expected ItemDeleted event, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn items_snapshot_produces_world_items_snapshot_event() {
+        let source = FoundrySource;
+        let msg = json!({
+            "type": "items",
+            "items": [
+                { "id": "i1", "name": "Iron Gullet", "type": "feature",
+                  "featuretype": "merit", "system": {} }
+            ]
+        });
+        let events = source.handle_inbound(msg).await.expect("handles");
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            InboundEvent::WorldItemsSnapshot { source: src, items } => {
+                assert_eq!(*src, SourceKind::Foundry);
+                assert_eq!(items.len(), 1);
+                assert_eq!(items[0].name, "Iron Gullet");
+            }
+            other => panic!("expected WorldItemsSnapshot, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn world_item_upsert_produces_event() {
+        let source = FoundrySource;
+        let msg = json!({
+            "type": "world_item_upsert",
+            "item": { "id": "i7", "name": "Bloodhound", "type": "feature",
+                      "featuretype": "merit", "system": {} }
+        });
+        let events = source.handle_inbound(msg).await.expect("handles");
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], InboundEvent::WorldItemUpsert { .. }));
+    }
+
+    #[tokio::test]
+    async fn world_item_deleted_produces_event() {
+        let source = FoundrySource;
+        let msg = json!({ "type": "world_item_deleted", "item_id": "i99" });
+        let events = source.handle_inbound(msg).await.expect("handles");
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            InboundEvent::WorldItemDeleted { source: src, item_id } => {
+                assert_eq!(*src, SourceKind::Foundry);
+                assert_eq!(item_id, "i99");
+            }
+            other => panic!("expected WorldItemDeleted, got {other:?}"),
         }
     }
 }

--- a/src-tauri/src/bridge/foundry/translate.rs
+++ b/src-tauri/src/bridge/foundry/translate.rs
@@ -5,8 +5,8 @@
 
 use serde_json::Value;
 
-use crate::bridge::foundry::types::FoundryActor;
-use crate::bridge::types::{CanonicalCharacter, HealthTrack, SourceKind};
+use crate::bridge::foundry::types::{FoundryActor, FoundryWorldItem};
+use crate::bridge::types::{CanonicalCharacter, CanonicalWorldItem, HealthTrack, SourceKind};
 
 pub fn to_canonical(raw: &FoundryActor) -> CanonicalCharacter {
     let sys = &raw.system;
@@ -47,5 +47,38 @@ fn value_to_u8(v: &Value) -> Option<u8> {
         Value::Number(n) => n.as_u64().and_then(|x| u8::try_from(x).ok()),
         Value::String(s) => s.parse::<u8>().ok(),
         _ => None,
+    }
+}
+
+pub fn to_canonical_world_item(item: &FoundryWorldItem) -> CanonicalWorldItem {
+    CanonicalWorldItem {
+        source: SourceKind::Foundry,
+        id: item.id.clone(),
+        name: item.name.clone(),
+        kind: item.item_type.clone(),
+        featuretype: item.featuretype.clone(),
+        system: item.system.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn translate_world_item_preserves_featuretype() {
+        let wire = FoundryWorldItem {
+            id: "i1".into(),
+            name: "Iron Gullet".into(),
+            item_type: "feature".into(),
+            featuretype: Some("merit".into()),
+            system: serde_json::json!({"description": "..."}),
+        };
+        let canonical = to_canonical_world_item(&wire);
+        assert_eq!(canonical.source, SourceKind::Foundry);
+        assert_eq!(canonical.id, "i1");
+        assert_eq!(canonical.name, "Iron Gullet");
+        assert_eq!(canonical.kind, "feature");
+        assert_eq!(canonical.featuretype.as_deref(), Some("merit"));
     }
 }

--- a/src-tauri/src/bridge/foundry/types.rs
+++ b/src-tauri/src/bridge/foundry/types.rs
@@ -45,6 +45,23 @@ pub enum FoundryInbound {
         actor_id: String,
         item_id: String,
     },
+    /// World-level item snapshot — pushed by the module on first
+    /// subscribe to `collection: "item"`. Replaces the entire cached
+    /// items slice for this source.
+    Items {
+        items: Vec<FoundryWorldItem>,
+    },
+    /// One world-level item was created or updated.
+    /// Triggered by the module's createItem / updateItem hooks
+    /// (filtered to parent === null).
+    WorldItemUpsert {
+        item: FoundryWorldItem,
+    },
+    /// One world-level item was deleted.
+    /// Triggered by the module's deleteItem hook (parent === null filter).
+    WorldItemDeleted {
+        item_id: String,
+    },
 }
 
 /// Wire shape for a Foundry roll result. JS-side `messageToWire`
@@ -89,6 +106,29 @@ pub struct FoundryActor {
     /// via `items` instead. Defaults to `Value::Null` for pre-0.4.0 payloads.
     #[serde(default)]
     pub effects: serde_json::Value,
+}
+
+/// World-level Item document. Distinct from embedded-on-actor items —
+/// those arrive via `FoundryActor::items` and stay scoped to their
+/// parent actor. World-level items have no parent (Foundry's
+/// `item.parent === null`); the module's `item` subscriber filters
+/// for them explicitly so this struct never carries an actor_id.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FoundryWorldItem {
+    /// Foundry document _id.
+    pub id: String,
+    pub name: String,
+    /// Foundry Item type ("feature", "speciality", "power", etc.).
+    #[serde(rename = "type")]
+    pub item_type: String,
+    /// system.featuretype when item.type == "feature" (merit/flaw/
+    /// background/boon). None for non-feature items.
+    #[serde(default)]
+    pub featuretype: Option<String>,
+    /// Raw `item.system` blob — opaque to Rust; Plan C's importer picks
+    /// fields (description, points, level) as needed.
+    #[serde(default)]
+    pub system: serde_json::Value,
 }
 
 /// Frontend → Tauri payload for applying a dyscrasia to a Foundry
@@ -259,6 +299,54 @@ mod tests {
                 assert_eq!(actor_id, "actor-xyz");
             }
             _ => panic!("expected ActorDeleted, got {parsed:?}"),
+        }
+    }
+
+    #[test]
+    fn items_snapshot_deserializes() {
+        let wire = r#"{
+            "type": "items",
+            "items": [
+                { "id": "i1", "name": "Iron Gullet", "type": "feature",
+                  "featuretype": "merit", "system": { "description": "..." } }
+            ]
+        }"#;
+        let parsed: FoundryInbound = serde_json::from_str(wire).expect("parses");
+        match parsed {
+            FoundryInbound::Items { items } => {
+                assert_eq!(items.len(), 1);
+                assert_eq!(items[0].name, "Iron Gullet");
+                assert_eq!(items[0].featuretype.as_deref(), Some("merit"));
+            }
+            other => panic!("expected Items, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn world_item_upsert_deserializes() {
+        let wire = r#"{
+            "type": "world_item_upsert",
+            "item": { "id": "i7", "name": "Bloodhound", "type": "feature",
+                      "featuretype": "merit", "system": {} }
+        }"#;
+        let parsed: FoundryInbound = serde_json::from_str(wire).expect("parses");
+        match parsed {
+            FoundryInbound::WorldItemUpsert { item } => {
+                assert_eq!(item.id, "i7");
+            }
+            other => panic!("expected WorldItemUpsert, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn world_item_deleted_deserializes() {
+        let wire = r#"{ "type": "world_item_deleted", "item_id": "i99" }"#;
+        let parsed: FoundryInbound = serde_json::from_str(wire).expect("parses");
+        match parsed {
+            FoundryInbound::WorldItemDeleted { item_id } => {
+                assert_eq!(item_id, "i99");
+            }
+            other => panic!("expected WorldItemDeleted, got {other:?}"),
         }
     }
 }

--- a/src-tauri/src/bridge/mod.rs
+++ b/src-tauri/src/bridge/mod.rs
@@ -48,6 +48,12 @@ pub struct BridgeState {
     // caches (characters, connections, source_info). tokio's Mutex doesn't
     // poison; push_roll / get_rolls are async because acquisition awaits.
     pub roll_history: Mutex<VecDeque<CanonicalRoll>>,
+    /// Cache of world-level Item documents per source. Keyed by SourceKind
+    /// then by canonical item id. Replaced wholesale per source on
+    /// `WorldItemsSnapshot`; per-entry mutated on Upsert/Delete.
+    pub world_items: Mutex<
+        HashMap<SourceKind, HashMap<String, crate::bridge::types::CanonicalWorldItem>>,
+    >,
 }
 
 impl BridgeState {
@@ -65,6 +71,7 @@ impl BridgeState {
             source_info: Mutex::new(HashMap::new()),
             sources,
             roll_history: Mutex::new(VecDeque::with_capacity(ROLL_HISTORY_CAPACITY)),
+            world_items: Mutex::new(HashMap::new()),
         }
     }
 
@@ -408,6 +415,36 @@ async fn handle_connection<S>(
                                 }
                             }
                         }
+                        InboundEvent::WorldItemsSnapshot { source, items } => {
+                            {
+                                let mut store = state.world_items.lock().await;
+                                let slot = store.entry(source).or_default();
+                                slot.clear();
+                                for i in &items {
+                                    slot.insert(i.id.clone(), i.clone());
+                                }
+                            }
+                            let snapshot = collect_world_items_snapshot(&state).await;
+                            let _ = handle.emit("bridge://foundry/items-updated", snapshot);
+                        }
+                        InboundEvent::WorldItemUpsert { source, item } => {
+                            {
+                                let mut store = state.world_items.lock().await;
+                                store.entry(source).or_default().insert(item.id.clone(), item);
+                            }
+                            let snapshot = collect_world_items_snapshot(&state).await;
+                            let _ = handle.emit("bridge://foundry/items-updated", snapshot);
+                        }
+                        InboundEvent::WorldItemDeleted { source, item_id } => {
+                            {
+                                let mut store = state.world_items.lock().await;
+                                if let Some(slot) = store.get_mut(&source) {
+                                    slot.remove(&item_id);
+                                }
+                            }
+                            let snapshot = collect_world_items_snapshot(&state).await;
+                            let _ = handle.emit("bridge://foundry/items-updated", snapshot);
+                        }
                     }
                 }
             }
@@ -428,6 +465,17 @@ async fn handle_connection<S>(
         info.remove(&kind);
     }
     let _ = handle.emit(&format!("bridge://{}/disconnected", kind.as_str()), ());
+}
+
+/// Flatten the per-source world-item caches into a single
+/// `Vec<CanonicalWorldItem>` for emission on
+/// `bridge://foundry/items-updated`. Mirrors the
+/// `characters` flatten pattern used in the snapshot arms above.
+async fn collect_world_items_snapshot(
+    state: &Arc<BridgeState>,
+) -> Vec<crate::bridge::types::CanonicalWorldItem> {
+    let store = state.world_items.lock().await;
+    store.values().flat_map(|m| m.values().cloned()).collect()
 }
 
 #[cfg(test)]

--- a/src-tauri/src/bridge/source.rs
+++ b/src-tauri/src/bridge/source.rs
@@ -33,6 +33,27 @@ pub enum InboundEvent {
         source_id: String,
         item_id: String,
     },
+    /// Source pushed a full world-level item snapshot. The bridge cache
+    /// replaces this source's world-items slice — every entry whose
+    /// `source` matches is dropped, then `items` are inserted. Empty
+    /// `items` is legal and means "this source now has zero
+    /// world-level items".
+    WorldItemsSnapshot {
+        source: crate::bridge::types::SourceKind,
+        items: Vec<crate::bridge::types::CanonicalWorldItem>,
+    },
+    /// One world-level item was added or changed. The bridge cache
+    /// inserts or overwrites a single entry keyed by `(source, id)`.
+    WorldItemUpsert {
+        source: crate::bridge::types::SourceKind,
+        item: crate::bridge::types::CanonicalWorldItem,
+    },
+    /// One world-level item was removed. The bridge cache evicts the
+    /// entry keyed by `(source, id)`.
+    WorldItemDeleted {
+        source: crate::bridge::types::SourceKind,
+        item_id: String,
+    },
 }
 
 /// Per-source protocol adapter. Sources are stateless transformers;

--- a/src-tauri/src/db/advantage.rs
+++ b/src-tauri/src/db/advantage.rs
@@ -1,6 +1,6 @@
 use rand::seq::SliceRandom;
 use sqlx::{Row, SqlitePool};
-use crate::shared::types::{Advantage, AdvantageKind, Field};
+use crate::shared::types::{Advantage, AdvantageKind, Field, ImportOutcome};
 
 // --------------------------------------------------------------------------
 // JSON serde helpers for tags_json and properties_json columns
@@ -230,6 +230,150 @@ async fn db_roll_random(
         return Ok(None);
     }
     Ok(pool_of_matches.choose(&mut rand::thread_rng()).cloned())
+}
+
+// --------------------------------------------------------------------------
+// FVTT import path (parallel to db_insert / db_update — preserves dedup
+// identity on the immutable Foundry document _id carried via
+// source_attribution.foundryId, NOT on the mutable display name).
+// --------------------------------------------------------------------------
+
+/// Identity lookup keyed on the immutable Foundry document id (carried via
+/// `source_attribution.foundryId`) scoped by `worldTitle`. Returns None for
+/// any row whose `source_attribution` is NULL (i.e. local rows never match).
+pub(crate) async fn db_find_by_foundry_id(
+    pool: &SqlitePool,
+    foundry_id: &str,
+    world_title: &str,
+) -> Result<Option<Advantage>, String> {
+    let row = sqlx::query(
+        "SELECT id, name, description, tags_json, properties_json, is_custom,
+                kind, source_attribution
+         FROM advantages
+         WHERE json_extract(source_attribution, '$.foundryId')  = ?
+           AND json_extract(source_attribution, '$.worldTitle') = ?
+         LIMIT 1"
+    )
+    .bind(foundry_id)
+    .bind(world_title)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| format!("db/advantage.find_by_foundry_id: {}", e))?;
+
+    match row {
+        Some(r) => Ok(Some(row_to_advantage(&r)?)),
+        None => Ok(None),
+    }
+}
+
+/// True iff any row matches (name, kind) regardless of attribution. Used by
+/// the import path to decide when to auto-suffix imported names so a
+/// hand-authored "Iron Gullet" can coexist with the FVTT-imported one.
+pub(crate) async fn db_collides_locally(
+    pool: &SqlitePool,
+    name: &str,
+    kind: AdvantageKind,
+) -> Result<bool, String> {
+    let row = sqlx::query("SELECT COUNT(*) AS c FROM advantages WHERE name = ? AND kind = ?")
+        .bind(name)
+        .bind(kind_to_str(kind))
+        .fetch_one(pool)
+        .await
+        .map_err(|e| format!("db/advantage.collides_locally: {}", e))?;
+    let c: i64 = row.get("c");
+    Ok(c > 0)
+}
+
+/// Import-flow workhorse. Resolves the dedup decision tree:
+///   - Same (foundryId, worldTitle) already imported → UPDATE in place
+///     (description, properties, attribution), preserving the row id and
+///     the stored name (which may already carry a suffix).
+///   - Different attribution but (name, kind) collides with any local row
+///     → auto-suffix "(FVTT — <worldTitle>)" and INSERT.
+///   - No collision → straight INSERT.
+///
+/// Imported rows are always `is_custom = 1` (survives destructive reseed,
+/// per ARCHITECTURE.md §6 tri-state) and start with empty tags.
+pub(crate) async fn db_upsert_imported(
+    pool: &SqlitePool,
+    name: &str,
+    kind: AdvantageKind,
+    description: &str,
+    properties: &[Field],
+    source_attribution: &serde_json::Value,
+) -> Result<ImportOutcome, String> {
+    let world_title = source_attribution
+        .get("worldTitle")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            "db/advantage.upsert_imported: source_attribution missing worldTitle".to_string()
+        })?;
+    let foundry_id = source_attribution
+        .get("foundryId")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            "db/advantage.upsert_imported: source_attribution missing foundryId".to_string()
+        })?;
+
+    // Case 1: same (foundryId, worldTitle) → UPDATE in place.
+    if let Some(existing) = db_find_by_foundry_id(pool, foundry_id, world_title).await? {
+        let properties_json = serialize_properties(properties)?;
+        let attribution_str = serde_json::to_string(source_attribution)
+            .map_err(|e| format!("db/advantage.upsert_imported: serialize attribution: {}", e))?;
+
+        sqlx::query(
+            "UPDATE advantages
+             SET description = ?, properties_json = ?, source_attribution = ?
+             WHERE id = ?"
+        )
+        .bind(description)
+        .bind(&properties_json)
+        .bind(&attribution_str)
+        .bind(existing.id)
+        .execute(pool)
+        .await
+        .map_err(|e| format!("db/advantage.upsert_imported: update: {}", e))?;
+
+        return Ok(ImportOutcome::Updated {
+            id: existing.id,
+            name: existing.name,
+            kind: existing.kind,
+        });
+    }
+
+    // Case 2 / 3: INSERT. Suffix name iff (name, kind) collides with any
+    // existing row (local hand-authored OR a different-world import).
+    let final_name = if db_collides_locally(pool, name, kind).await? {
+        format!("{} (FVTT — {})", name, world_title)
+    } else {
+        name.to_string()
+    };
+
+    let tags_json = serialize_tags(&[])?;
+    let properties_json = serialize_properties(properties)?;
+    let attribution_str = serde_json::to_string(source_attribution)
+        .map_err(|e| format!("db/advantage.upsert_imported: serialize attribution: {}", e))?;
+
+    let result = sqlx::query(
+        "INSERT INTO advantages
+            (name, description, tags_json, properties_json, is_custom, kind, source_attribution)
+         VALUES (?, ?, ?, ?, 1, ?, ?)"
+    )
+    .bind(&final_name)
+    .bind(description)
+    .bind(&tags_json)
+    .bind(&properties_json)
+    .bind(kind_to_str(kind))
+    .bind(&attribution_str)
+    .execute(pool)
+    .await
+    .map_err(|e| format!("db/advantage.upsert_imported: insert: {}", e))?;
+
+    Ok(ImportOutcome::Inserted {
+        id: result.last_insert_rowid(),
+        name: final_name,
+        kind,
+    })
 }
 
 // --------------------------------------------------------------------------
@@ -507,5 +651,213 @@ mod tests {
         let flaws = db_list_by_kind(&pool, AdvantageKind::Flaw).await.unwrap();
         assert_eq!(flaws.len(), 2);
         assert!(flaws.iter().all(|r| r.kind == AdvantageKind::Flaw));
+    }
+
+    // ─── New tests: FVTT import dedup helpers ───────────────────────────
+
+    fn world_attribution(world: &str, foundry_id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "source": "foundry",
+            "worldTitle": world,
+            "foundryId": foundry_id,
+            "importedAt": "2026-05-14T12:00:00Z",
+        })
+    }
+
+    #[tokio::test]
+    async fn upsert_imported_new_row_inserts() {
+        let pool = test_pool().await;
+        let out = db_upsert_imported(
+            &pool,
+            "Iron Gullet",
+            AdvantageKind::Merit,
+            "desc",
+            &[],
+            &world_attribution("Chicago", "chi_iron"),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(out, ImportOutcome::Inserted { ref name, .. } if name == "Iron Gullet"));
+    }
+
+    #[tokio::test]
+    async fn upsert_imported_same_world_updates_in_place() {
+        let pool = test_pool().await;
+        let first = db_upsert_imported(
+            &pool,
+            "Iron Gullet",
+            AdvantageKind::Merit,
+            "desc1",
+            &[],
+            &world_attribution("Chicago", "chi_iron"),
+        )
+        .await
+        .unwrap();
+        let first_id = match first {
+            ImportOutcome::Inserted { id, .. } => id,
+            other => panic!("expected Inserted on first import, got {other:?}"),
+        };
+
+        let second = db_upsert_imported(
+            &pool,
+            "Iron Gullet",
+            AdvantageKind::Merit,
+            "desc2 (revised)",
+            &[],
+            &world_attribution("Chicago", "chi_iron"),
+        )
+        .await
+        .unwrap();
+
+        match second {
+            ImportOutcome::Updated { id, .. } => assert_eq!(id, first_id),
+            other => panic!("expected Updated, got {other:?}"),
+        }
+        let rows = db_list(&pool).await.unwrap();
+        assert_eq!(rows.iter().filter(|r| r.name == "Iron Gullet").count(), 1);
+        assert_eq!(
+            rows.iter().find(|r| r.id == first_id).unwrap().description,
+            "desc2 (revised)"
+        );
+    }
+
+    #[tokio::test]
+    async fn upsert_imported_different_world_suffixes_name() {
+        let pool = test_pool().await;
+        db_upsert_imported(
+            &pool,
+            "Iron Gullet",
+            AdvantageKind::Merit,
+            "d",
+            &[],
+            &world_attribution("Chicago", "chi_iron"),
+        )
+        .await
+        .unwrap();
+
+        let second = db_upsert_imported(
+            &pool,
+            "Iron Gullet",
+            AdvantageKind::Merit,
+            "d",
+            &[],
+            &world_attribution("Berlin", "ber_iron"),
+        )
+        .await
+        .unwrap();
+
+        match second {
+            ImportOutcome::Inserted { name, .. } => {
+                assert_eq!(name, "Iron Gullet (FVTT — Berlin)");
+            }
+            other => panic!("expected Inserted with suffix, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn upsert_imported_suffixes_against_local_row() {
+        let pool = test_pool().await;
+        db_insert(&pool, "Iron Gullet", "local desc", AdvantageKind::Merit, None, &[], &[])
+            .await
+            .unwrap();
+
+        let imported = db_upsert_imported(
+            &pool,
+            "Iron Gullet",
+            AdvantageKind::Merit,
+            "fvtt desc",
+            &[],
+            &world_attribution("Chicago", "chi_iron"),
+        )
+        .await
+        .unwrap();
+
+        match imported {
+            ImportOutcome::Inserted { name, .. } => {
+                assert_eq!(name, "Iron Gullet (FVTT — Chicago)");
+            }
+            other => panic!("expected Inserted with suffix, got {other:?}"),
+        }
+        let rows = db_list(&pool).await.unwrap();
+        let names: Vec<_> = rows.iter().map(|r| r.name.as_str()).collect();
+        assert!(names.contains(&"Iron Gullet"));
+        assert!(names.contains(&"Iron Gullet (FVTT — Chicago)"));
+    }
+
+    #[tokio::test]
+    async fn upsert_imported_repull_of_secondary_world_updates_in_place() {
+        let pool = test_pool().await;
+
+        let chi = db_upsert_imported(
+            &pool,
+            "Iron Gullet",
+            AdvantageKind::Merit,
+            "v1",
+            &[],
+            &world_attribution("Chicago", "chi_iron"),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(chi, ImportOutcome::Inserted { ref name, .. } if name == "Iron Gullet"));
+
+        let ber1 = db_upsert_imported(
+            &pool,
+            "Iron Gullet",
+            AdvantageKind::Merit,
+            "v1",
+            &[],
+            &world_attribution("Berlin", "ber_iron"),
+        )
+        .await
+        .unwrap();
+        let ber_id = match ber1 {
+            ImportOutcome::Inserted { id, name, .. } => {
+                assert_eq!(name, "Iron Gullet (FVTT — Berlin)");
+                id
+            }
+            other => panic!("expected suffixed Inserted, got {other:?}"),
+        };
+
+        let ber2 = db_upsert_imported(
+            &pool,
+            "Iron Gullet",
+            AdvantageKind::Merit,
+            "v2",
+            &[],
+            &world_attribution("Berlin", "ber_iron"),
+        )
+        .await
+        .unwrap();
+        match ber2 {
+            ImportOutcome::Updated { id, .. } => assert_eq!(id, ber_id),
+            other => panic!("expected Updated on re-pull of secondary world, got {other:?}"),
+        }
+        let rows = db_list(&pool).await.unwrap();
+        let berlin_rows = rows
+            .iter()
+            .filter(|r| r.name == "Iron Gullet (FVTT — Berlin)")
+            .count();
+        assert_eq!(
+            berlin_rows, 1,
+            "re-pull of secondary-world item must update in place, not duplicate"
+        );
+        let chicago_rows = rows.iter().filter(|r| r.name == "Iron Gullet").count();
+        assert_eq!(
+            chicago_rows, 1,
+            "Chicago row must be untouched by Berlin re-pull"
+        );
+    }
+
+    #[tokio::test]
+    async fn find_by_foundry_id_returns_none_for_local_row() {
+        let pool = test_pool().await;
+        db_insert(&pool, "Allies", "local", AdvantageKind::Background, None, &[], &[])
+            .await
+            .unwrap();
+        let found = db_find_by_foundry_id(&pool, "any_id", "Chicago").await.unwrap();
+        assert!(
+            found.is_none(),
+            "local row (NULL attribution) must never match a foundryId lookup"
+        );
     }
 }

--- a/src-tauri/src/db/advantage.rs
+++ b/src-tauri/src/db/advantage.rs
@@ -180,9 +180,17 @@ async fn db_update(
         None => None,
     };
 
+    // `source_attribution` uses COALESCE so a NULL bind preserves the
+    // existing column value. The GM-edit path (`update_advantage` Tauri
+    // command) always binds None and must NOT wipe import provenance —
+    // wiping it would break the foundryId-keyed re-pull dedup in
+    // `db_upsert_imported` (the next pull would miss and INSERT a
+    // duplicate row). Callers that want to overwrite attribution should
+    // pass Some(value); callers that want to leave it alone pass None.
     let result = sqlx::query(
         "UPDATE advantages
-         SET name = ?, description = ?, tags_json = ?, properties_json = ?, kind = ?, source_attribution = ?
+         SET name = ?, description = ?, tags_json = ?, properties_json = ?, kind = ?,
+             source_attribution = COALESCE(?, source_attribution)
          WHERE id = ? AND is_custom = 1"
     )
     .bind(name)
@@ -1123,5 +1131,91 @@ mod tests {
             "error message missing prefix: {err}"
         );
         assert!(err.contains("no active Foundry"), "unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn update_preserves_source_attribution_for_imported_rows() {
+        // Regression: editing an imported row via the GM-facing update path
+        // (Tauri `update_advantage` → `db_update(..., None, ...)`) must NOT
+        // wipe `source_attribution`. Otherwise the foundryId-keyed re-pull
+        // dedup (db_find_by_foundry_id) misses on the next pull and
+        // re-INSERTs the same Foundry item as a duplicate row.
+        let pool = test_pool().await;
+
+        let attribution = world_attribution("Chicago", "chi_iron");
+        let inserted = db_upsert_imported(
+            &pool,
+            "Iron Gullet",
+            AdvantageKind::Merit,
+            "v1 desc",
+            &[],
+            &attribution,
+        )
+        .await
+        .unwrap();
+        let row_id = match inserted {
+            ImportOutcome::Inserted { id, .. } => id,
+            other => panic!("expected Inserted on fresh import, got {other:?}"),
+        };
+
+        // Simulate the GM clicking Edit on the imported row. The Tauri
+        // `update_advantage` command forwards None for source_attribution
+        // (the frontend AdvantageInput has no attribution field).
+        db_update(
+            &pool,
+            row_id,
+            "Iron Gullet (typo fix)",
+            "v1 with fixed typo",
+            AdvantageKind::Merit,
+            None,
+            &[],
+            &[],
+        )
+        .await
+        .unwrap();
+
+        // The foundryId lookup must still match → source_attribution survived.
+        let found = db_find_by_foundry_id(&pool, "chi_iron", "Chicago")
+            .await
+            .unwrap();
+        assert!(
+            found.is_some(),
+            "db_find_by_foundry_id must still match after GM edit; \
+             source_attribution must be preserved by db_update"
+        );
+        let row = found.unwrap();
+        assert_eq!(row.id, row_id);
+        assert_eq!(row.name, "Iron Gullet (typo fix)");
+        assert!(
+            row.source_attribution.is_some(),
+            "source_attribution must not be wiped by db_update"
+        );
+
+        // Re-pull (idempotency check). Must Update in place, NOT Insert a
+        // duplicate. This is the user-visible manifestation of the bug.
+        let repulled = db_upsert_imported(
+            &pool,
+            "Iron Gullet",
+            AdvantageKind::Merit,
+            "v2 desc",
+            &[],
+            &attribution,
+        )
+        .await
+        .unwrap();
+        match repulled {
+            ImportOutcome::Updated { id, .. } => assert_eq!(id, row_id),
+            other => panic!("expected Updated on re-pull after GM edit, got {other:?}"),
+        }
+
+        let all = db_list(&pool).await.unwrap();
+        let imported = all
+            .iter()
+            .filter(|r| r.source_attribution.is_some())
+            .count();
+        assert_eq!(
+            imported, 1,
+            "GM edit + re-pull must leave exactly one imported row, not duplicate"
+        );
     }
 }

--- a/src-tauri/src/db/advantage.rs
+++ b/src-tauri/src/db/advantage.rs
@@ -1,6 +1,9 @@
 use rand::seq::SliceRandom;
 use sqlx::{Row, SqlitePool};
-use crate::shared::types::{Advantage, AdvantageKind, Field, ImportOutcome};
+use crate::bridge::{BridgeConn, BridgeState, types::SourceKind};
+use crate::shared::types::{
+    Advantage, AdvantageKind, Field, FieldValue, ImportOutcome, NumberFieldValue,
+};
 
 // --------------------------------------------------------------------------
 // JSON serde helpers for tags_json and properties_json columns
@@ -377,6 +380,120 @@ pub(crate) async fn db_upsert_imported(
 }
 
 // --------------------------------------------------------------------------
+// FVTT import orchestration (inner helper + Tauri wrapper)
+//
+// Split into an inner helper that takes `&SqlitePool` + `&BridgeState`
+// (unit-testable without a Tauri runtime) and a thin `#[tauri::command]`
+// wrapper that extracts the State references and delegates. Mirrors the
+// `db_list` / `list_advantages` pattern used throughout this file.
+// --------------------------------------------------------------------------
+
+/// Snapshot the active Foundry world info + cached world items, filter to
+/// feature-type rows with a known featuretype, and per-row delegate to
+/// `db_upsert_imported`. Non-feature items and unknown featuretypes are
+/// returned as `ImportOutcome::Skipped` for the frontend's summary toast.
+///
+/// Error prefix `db/advantage.import_from_world:` per ARCH §7.
+pub(crate) async fn db_import_from_world(
+    pool: &SqlitePool,
+    bridge: &BridgeState,
+) -> Result<Vec<ImportOutcome>, String> {
+    // Snapshot Foundry source info under one lock acquisition. world_title
+    // is required (it's the dedup-scope key); world_id and system_version
+    // are optional metadata stamped into source_attribution.
+    let (world_title, world_id, system_version) = {
+        let info = bridge.source_info.lock().await;
+        let i = info.get(&SourceKind::Foundry).ok_or_else(|| {
+            "db/advantage.import_from_world: no active Foundry connection".to_string()
+        })?;
+        let world_title = i.world_title.clone().ok_or_else(|| {
+            "db/advantage.import_from_world: no active Foundry world (connect first?)"
+                .to_string()
+        })?;
+        (world_title, i.world_id.clone(), i.system_version.clone())
+    };
+
+    let items: Vec<crate::bridge::types::CanonicalWorldItem> = {
+        let store = bridge.world_items.lock().await;
+        store
+            .get(&SourceKind::Foundry)
+            .map(|m| m.values().cloned().collect())
+            .unwrap_or_default()
+    };
+
+    let now = chrono::Utc::now().to_rfc3339();
+
+    let mut outcomes = Vec::with_capacity(items.len());
+    for item in items {
+        if item.kind != "feature" {
+            outcomes.push(ImportOutcome::Skipped {
+                reason: format!("non-feature item kind: {}", item.kind),
+                name: item.name,
+            });
+            continue;
+        }
+        let ft = match item.featuretype.as_deref() {
+            Some("merit")      => AdvantageKind::Merit,
+            Some("flaw")       => AdvantageKind::Flaw,
+            Some("background") => AdvantageKind::Background,
+            Some("boon")       => AdvantageKind::Boon,
+            other => {
+                outcomes.push(ImportOutcome::Skipped {
+                    reason: format!("unknown featuretype: {:?}", other),
+                    name: item.name,
+                });
+                continue;
+            }
+        };
+
+        let description = item
+            .system
+            .get("description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let points = item
+            .system
+            .get("points")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32;
+
+        let properties: Vec<Field> = if points > 0 {
+            vec![Field {
+                name: "level".into(),
+                value: FieldValue::Number {
+                    value: NumberFieldValue::Single(points as f64),
+                },
+            }]
+        } else {
+            vec![]
+        };
+
+        let attribution = serde_json::json!({
+            "source":        "foundry",
+            "worldTitle":    world_title,
+            "worldId":       world_id,
+            "systemVersion": system_version,
+            "foundryId":     item.id,
+            "importedAt":    now,
+        });
+
+        let outcome = db_upsert_imported(
+            pool,
+            &item.name,
+            ft,
+            &description,
+            &properties,
+            &attribution,
+        )
+        .await?;
+        outcomes.push(outcome);
+    }
+
+    Ok(outcomes)
+}
+
+// --------------------------------------------------------------------------
 // Tauri command handlers (thin wrappers around the helpers above)
 // --------------------------------------------------------------------------
 
@@ -426,6 +543,23 @@ pub async fn roll_random_advantage(
     tags: Vec<String>,
 ) -> Result<Option<Advantage>, String> {
     db_roll_random(&pool.0, &tags).await
+}
+
+/// Import feature-type world items from the active Foundry world into the
+/// local advantages library. Pulls from `BridgeState.world_items` — the
+/// frontend must have subscribed to the `item` collection beforehand
+/// (Task 6 wires the subscription).
+///
+/// Filter: only `kind == "feature"` items with featuretype ∈ {merit,
+/// flaw, background, boon}. Other item kinds (speciality, power, etc.)
+/// and unknown featuretypes are returned as `ImportOutcome::Skipped` for
+/// the frontend's summary toast.
+#[tauri::command]
+pub async fn import_advantages_from_world(
+    db: tauri::State<'_, crate::DbState>,
+    bridge: tauri::State<'_, BridgeConn>,
+) -> Result<Vec<ImportOutcome>, String> {
+    db_import_from_world(&db.0, &bridge.0).await
 }
 
 #[cfg(test)]
@@ -859,5 +993,135 @@ mod tests {
             found.is_none(),
             "local row (NULL attribution) must never match a foundryId lookup"
         );
+    }
+
+    // ─── Integration test: db_import_from_world filter + orchestration ──
+
+    #[tokio::test]
+    async fn import_from_world_filters_non_feature_and_unknown_featuretype() {
+        use crate::bridge::types::{CanonicalWorldItem, SourceInfo};
+        use std::collections::HashMap;
+
+        let pool = test_pool().await;
+
+        // Construct a real BridgeState with empty sources map (the import
+        // path only reads source_info + world_items — never invokes the
+        // BridgeSource trait — so an empty sources HashMap is fine).
+        let bridge = BridgeState::new(HashMap::new());
+        {
+            let mut info = bridge.source_info.lock().await;
+            info.insert(
+                SourceKind::Foundry,
+                SourceInfo {
+                    world_id:         Some("world_chi".into()),
+                    world_title:      Some("Chicago".into()),
+                    system_id:        Some("vtm5e".into()),
+                    system_version:   Some("0.9.0".into()),
+                    protocol_version: 1,
+                    capabilities:     vec!["actors".into(), "items".into()],
+                },
+            );
+        }
+        {
+            let mut store = bridge.world_items.lock().await;
+            let slot = store.entry(SourceKind::Foundry).or_default();
+            slot.insert(
+                "merit_id".into(),
+                CanonicalWorldItem {
+                    source: SourceKind::Foundry,
+                    id:     "merit_id".into(),
+                    name:   "Iron Gullet".into(),
+                    kind:   "feature".into(),
+                    featuretype: Some("merit".into()),
+                    system: serde_json::json!({
+                        "description": "Can drink rancid blood",
+                        "points":      1,
+                    }),
+                },
+            );
+            slot.insert(
+                "spec_id".into(),
+                CanonicalWorldItem {
+                    source: SourceKind::Foundry,
+                    id:     "spec_id".into(),
+                    name:   "Survival: Urban".into(),
+                    kind:   "speciality".into(),
+                    featuretype: None,
+                    system: serde_json::json!({}),
+                },
+            );
+            slot.insert(
+                "unknown_ft_id".into(),
+                CanonicalWorldItem {
+                    source: SourceKind::Foundry,
+                    id:     "unknown_ft_id".into(),
+                    name:   "Mystery Feature".into(),
+                    kind:   "feature".into(),
+                    featuretype: Some("discipline".into()),
+                    system: serde_json::json!({}),
+                },
+            );
+        }
+
+        let outcomes = db_import_from_world(&pool, &bridge).await.unwrap();
+        assert_eq!(outcomes.len(), 3, "one outcome per snapshot item");
+
+        // HashMap iteration order is unspecified — partition by variant.
+        let mut inserted = 0;
+        let mut skipped_non_feature = 0;
+        let mut skipped_unknown_ft = 0;
+        for o in &outcomes {
+            match o {
+                ImportOutcome::Inserted { name, kind, .. } => {
+                    inserted += 1;
+                    assert_eq!(name, "Iron Gullet");
+                    assert_eq!(*kind, AdvantageKind::Merit);
+                }
+                ImportOutcome::Skipped { reason, .. } => {
+                    if reason.contains("non-feature") {
+                        skipped_non_feature += 1;
+                    } else if reason.contains("unknown featuretype") {
+                        skipped_unknown_ft += 1;
+                    } else {
+                        panic!("unexpected Skipped reason: {reason}");
+                    }
+                }
+                ImportOutcome::Updated { .. } => {
+                    panic!("expected Inserted, got Updated on a fresh import")
+                }
+            }
+        }
+        assert_eq!(inserted, 1, "merit feature should Insert");
+        assert_eq!(skipped_non_feature, 1, "speciality should Skip (non-feature)");
+        assert_eq!(skipped_unknown_ft, 1, "unknown featuretype should Skip");
+
+        // Verify the inserted row landed in the DB with correct attribution.
+        let rows = db_list(&pool).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        let r = &rows[0];
+        assert_eq!(r.name, "Iron Gullet");
+        assert_eq!(r.kind, AdvantageKind::Merit);
+        let attrib = r.source_attribution.as_ref().unwrap();
+        assert_eq!(attrib["worldTitle"], "Chicago");
+        assert_eq!(attrib["worldId"], "world_chi");
+        assert_eq!(attrib["systemVersion"], "0.9.0");
+        assert_eq!(attrib["foundryId"], "merit_id");
+        assert_eq!(attrib["source"], "foundry");
+        // Properties should carry a level=1 field since points > 0.
+        assert_eq!(r.properties.len(), 1);
+        assert_eq!(r.properties[0].name, "level");
+    }
+
+    #[tokio::test]
+    async fn import_from_world_errors_when_no_foundry_connected() {
+        use std::collections::HashMap;
+        let pool = test_pool().await;
+        let bridge = BridgeState::new(HashMap::new());
+        let err = db_import_from_world(&pool, &bridge).await.unwrap_err();
+        assert!(
+            err.contains("db/advantage.import_from_world"),
+            "error message missing prefix: {err}"
+        );
+        assert!(err.contains("no active Foundry"), "unexpected error: {err}");
     }
 }

--- a/src-tauri/src/db/advantage.rs
+++ b/src-tauri/src/db/advantage.rs
@@ -76,7 +76,7 @@ fn row_to_advantage(r: &sqlx::sqlite::SqliteRow) -> Result<Advantage, String> {
     })
 }
 
-async fn db_list(pool: &SqlitePool) -> Result<Vec<Advantage>, String> {
+pub(crate) async fn db_list(pool: &SqlitePool) -> Result<Vec<Advantage>, String> {
     let rows = sqlx::query(
         "SELECT id, name, description, tags_json, properties_json, is_custom, kind, source_attribution
          FROM advantages ORDER BY is_custom ASC, id ASC"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -128,6 +128,7 @@ pub fn run() {
             db::advantage::update_advantage,
             db::advantage::delete_advantage,
             db::advantage::roll_random_advantage,
+            db::advantage::import_advantages_from_world,
             tools::library_push::push_advantage_to_world,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,6 +79,7 @@ pub fn run() {
             tools::character::character_remove_advantage,
             bridge::commands::bridge_get_characters,
             bridge::commands::bridge_get_rolls,
+            bridge::commands::bridge_get_world_items,
             bridge::commands::bridge_get_status,
             bridge::commands::bridge_refresh,
             bridge::commands::bridge_set_attribute,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -80,6 +80,8 @@ pub fn run() {
             bridge::commands::bridge_get_characters,
             bridge::commands::bridge_get_rolls,
             bridge::commands::bridge_get_world_items,
+            bridge::commands::bridge_subscribe,
+            bridge::commands::bridge_unsubscribe,
             bridge::commands::bridge_get_status,
             bridge::commands::bridge_refresh,
             bridge::commands::bridge_set_attribute,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -128,6 +128,7 @@ pub fn run() {
             db::advantage::update_advantage,
             db::advantage::delete_advantage,
             db::advantage::roll_random_advantage,
+            tools::library_push::push_advantage_to_world,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/shared/types.rs
+++ b/src-tauri/src/shared/types.rs
@@ -156,6 +156,20 @@ pub struct Advantage {
     pub source_attribution: Option<serde_json::Value>,
 }
 
+/// Outcome of one import attempt for a single world item.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum ImportOutcome {
+    /// Row didn't exist locally. Inserted as-is (may include world-suffix
+    /// in the name if a same-name local row already existed).
+    Inserted { id: i64, name: String, kind: AdvantageKind },
+    /// Same (foundryId, worldTitle) already imported here. Updated description
+    /// + bumped imported_at; row id preserved.
+    Updated  { id: i64, name: String, kind: AdvantageKind },
+    /// Filtered out (non-feature item.kind, or unrecognized featuretype).
+    Skipped  { reason: String, name: String },
+}
+
 /// Full result of one resonance roll sequence
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/tools/character.rs
+++ b/src-tauri/src/tools/character.rs
@@ -388,6 +388,7 @@ mod tests {
             source_info: Mutex::new(HashMap::new()),
             sources,
             roll_history: Mutex::new(std::collections::VecDeque::new()),
+            world_items: Mutex::new(HashMap::new()),
         });
         (state, rx_opt)
     }

--- a/src-tauri/src/tools/gm_screen.rs
+++ b/src-tauri/src/tools/gm_screen.rs
@@ -530,6 +530,7 @@ mod tests {
             source_info: Mutex::new(HashMap::new()),
             sources,
             roll_history: Mutex::new(std::collections::VecDeque::new()),
+            world_items: Mutex::new(HashMap::new()),
         })
     }
 

--- a/src-tauri/src/tools/library_push.rs
+++ b/src-tauri/src/tools/library_push.rs
@@ -1,0 +1,105 @@
+//! Library push: send a local advantage row → active Foundry world as a
+//! world-level Item doc. Composes
+//! `bridge::foundry::actions::storyteller::build_create_world_item`. No-op if
+//! Foundry isn't connected (silent success — matches bridge_set_attribute
+//! semantics; the UI gates the button on connectivity).
+
+use crate::bridge::foundry::actions::storyteller::build_create_world_item;
+use crate::bridge::types::SourceKind;
+use crate::bridge::{commands::send_to_source_inner, BridgeConn};
+use crate::shared::types::AdvantageKind;
+use tauri::State;
+
+fn kind_to_featuretype(k: AdvantageKind) -> &'static str {
+    match k {
+        AdvantageKind::Merit      => "merit",
+        AdvantageKind::Flaw       => "flaw",
+        AdvantageKind::Background => "background",
+        AdvantageKind::Boon       => "boon",
+    }
+}
+
+/// Look for `level` (preferred) or fall back to `min_level`. Anything not
+/// found → 0. Mirrors the existing AdvantagesManager dot-display fallback.
+///
+/// Note: `NumberFieldValue` is `Single(f64) | Multi(Vec<f64>)` in this
+/// codebase (the plan template referenced a `Range(min, _)` variant that
+/// does not exist). For `Multi`, the smallest value is used — preserves
+/// the plan's "min of a range" semantic.
+fn extract_points(properties: &[crate::shared::types::Field]) -> i32 {
+    for f in properties {
+        if f.name == "level" || f.name == "min_level" {
+            if let crate::shared::types::FieldValue::Number { value } = &f.value {
+                match value {
+                    crate::shared::types::NumberFieldValue::Single(n) => return *n as i32,
+                    crate::shared::types::NumberFieldValue::Multi(vs) => {
+                        // Empty Multi → 0; otherwise min value (preserves
+                        // the plan's "min of a range" semantic).
+                        let min = vs.iter().cloned().fold(f64::INFINITY, f64::min);
+                        return if min.is_finite() { min as i32 } else { 0 };
+                    }
+                }
+            }
+        }
+    }
+    0
+}
+
+#[tauri::command]
+pub async fn push_advantage_to_world(
+    db: State<'_, crate::DbState>,
+    conn: State<'_, BridgeConn>,
+    id: i64,
+) -> Result<(), String> {
+    let all = crate::db::advantage::db_list(&db.0).await?;
+    let row = all.iter().find(|r| r.id == id)
+        .ok_or_else(|| format!("tools/library_push: advantage {id} not found"))?;
+
+    let payload = build_create_world_item(
+        &row.name,
+        kind_to_featuretype(row.kind),
+        &row.description,
+        extract_points(&row.properties),
+    )?;
+
+    let text = serde_json::to_string(&payload)
+        .map_err(|e| format!("tools/library_push: serialize: {e}"))?;
+    send_to_source_inner(&conn.0, SourceKind::Foundry, text).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared::types::{AdvantageKind, Field, FieldValue, NumberFieldValue};
+
+    #[test]
+    fn extract_points_reads_level_field() {
+        let props = vec![Field {
+            name: "level".into(),
+            value: FieldValue::Number { value: NumberFieldValue::Single(3.0) },
+        }];
+        assert_eq!(extract_points(&props), 3);
+    }
+
+    #[test]
+    fn extract_points_reads_min_level_for_ranged() {
+        let props = vec![Field {
+            name: "min_level".into(),
+            value: FieldValue::Number { value: NumberFieldValue::Single(1.0) },
+        }];
+        assert_eq!(extract_points(&props), 1);
+    }
+
+    #[test]
+    fn extract_points_returns_zero_when_absent() {
+        assert_eq!(extract_points(&[]), 0);
+    }
+
+    #[test]
+    fn kind_maps_to_featuretype_one_to_one() {
+        assert_eq!(kind_to_featuretype(AdvantageKind::Merit),      "merit");
+        assert_eq!(kind_to_featuretype(AdvantageKind::Flaw),       "flaw");
+        assert_eq!(kind_to_featuretype(AdvantageKind::Background), "background");
+        assert_eq!(kind_to_featuretype(AdvantageKind::Boon),       "boon");
+    }
+}

--- a/src-tauri/src/tools/mod.rs
+++ b/src-tauri/src/tools/mod.rs
@@ -4,3 +4,4 @@ pub mod export;
 pub mod foundry_chat;
 pub mod character;
 pub mod gm_screen;
+pub mod library_push;

--- a/src/lib/bridge/api.ts
+++ b/src/lib/bridge/api.ts
@@ -2,9 +2,9 @@
 // components must NOT call invoke() directly — they go through here.
 
 import { invoke } from '@tauri-apps/api/core';
-import type { BridgeCharacter, CanonicalRoll, SourceKind } from '../../types';
+import type { BridgeCharacter, CanonicalRoll, CanonicalWorldItem, SourceKind } from '../../types';
 
-export type { BridgeCharacter, CanonicalRoll, SourceKind };
+export type { BridgeCharacter, CanonicalRoll, CanonicalWorldItem, SourceKind };
 
 export interface SourceInfo {
   worldId: string | null;
@@ -37,3 +37,6 @@ export const setAttribute = (
 
 export const bridgeGetSourceInfo = (source: SourceKind): Promise<SourceInfo | null> =>
   invoke<SourceInfo | null>('bridge_get_source_info', { source });
+
+export const bridgeGetWorldItems = (): Promise<CanonicalWorldItem[]> =>
+  invoke<CanonicalWorldItem[]>('bridge_get_world_items');

--- a/src/lib/components/AdvantageCard.svelte
+++ b/src/lib/components/AdvantageCard.svelte
@@ -68,6 +68,11 @@
     <h3 class="name">{entry.name}</h3>
     <div class="tags">
       <span class="tag kind-chip" data-kind={entry.kind}>{capitalize(entry.kind)}</span>
+      {#if entry.sourceAttribution}
+        <span class="tag source-chip" data-source={(entry.sourceAttribution.source as string | undefined) ?? 'foundry'}>
+          FVTT · {(entry.sourceAttribution.worldTitle as string | undefined) ?? '?'}
+        </span>
+      {/if}
       {#each entry.tags as t}
         <span class="tag">{t}</span>
       {/each}
@@ -155,6 +160,18 @@
   .kind-chip[data-kind="flaw"]       { background: var(--accent-flaw,       var(--accent-bright)); }
   .kind-chip[data-kind="background"] { background: var(--accent-background, var(--accent-card-dossier)); }
   .kind-chip[data-kind="boon"]       { background: var(--accent-boon,       var(--accent-amber)); }
+  /* Source-attribution chip — visually distinguishes imported (FVTT)
+     rows from corebook + locally-authored ones. Mirrors the kind-chip
+     shape so the two chips read as a paired strip. Uses token
+     fallbacks since a dedicated --accent-foundry token isn't defined
+     in :root yet. */
+  .source-chip {
+    color: var(--text-primary);
+    font-variant: small-caps;
+    letter-spacing: 0.04em;
+  }
+  .source-chip[data-source="foundry"] { background: var(--accent-foundry, var(--accent-card-dossier)); }
+  .source-chip[data-source="roll20"]  { background: var(--accent-roll20,  var(--accent-merit)); }
   .desc { color: var(--text-secondary); font-size: 0.74rem; margin: 0; line-height: 1.4; }
   .dots { color: var(--text-ghost); letter-spacing: 0.08em; font-size: 0.85rem; }
   .dots .filled { color: var(--accent); }

--- a/src/lib/components/AdvantageCard.svelte
+++ b/src/lib/components/AdvantageCard.svelte
@@ -1,11 +1,28 @@
 <script lang="ts">
   import type { Advantage, Field } from '../../types';
+  import { bridge } from '../../store/bridge.svelte';
+  import { pushAdvantageToWorld } from '$lib/library/api';
 
   const { entry, onedit, ondelete }: {
     entry: Advantage;
     onedit?: () => void;
     ondelete?: () => void;
   } = $props();
+
+  let pushing = $state(false);
+  let pushError = $state('');
+
+  async function handlePush() {
+    pushing = true;
+    pushError = '';
+    try {
+      await pushAdvantageToWorld(entry.id);
+    } catch (e) {
+      pushError = String(e);
+    } finally {
+      pushing = false;
+    }
+  }
 
   function findField(name: string): Field | undefined {
     return entry.properties.find(p => p.name === name);
@@ -82,6 +99,18 @@
   {/if}
 
   <footer class="foot">
+    {#if pushError}
+      <span class="push-error" title={pushError}>!</span>
+    {/if}
+    {#if bridge.connections.foundry}
+      <button
+        class="btn push"
+        onclick={handlePush}
+        disabled={pushing}
+        aria-label="Push to world"
+        title="Push to Foundry world"
+      >{pushing ? '…' : '⇡'}</button>
+    {/if}
     {#if entry.isCustom}
       <button class="btn edit"   onclick={onedit}   aria-label="Edit">✎</button>
       <button class="btn delete" onclick={ondelete} aria-label="Delete">✕</button>
@@ -145,5 +174,13 @@
     transition: color 0.15s, border-color 0.15s;
   }
   .btn:hover { color: var(--accent); border-color: var(--accent); }
+  .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .push-error {
+    color: var(--accent);
+    font-weight: bold;
+    font-size: 0.72rem;
+    align-self: center;
+    cursor: help;
+  }
   .builtin { color: var(--text-ghost); font-size: 0.62rem; font-style: italic; }
 </style>

--- a/src/lib/library/api.ts
+++ b/src/lib/library/api.ts
@@ -1,4 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
+import type { ImportOutcome } from '../../types';
 
 /**
  * Push a local advantage row → active Foundry world as a world-level
@@ -11,4 +12,39 @@ import { invoke } from '@tauri-apps/api/core';
  */
 export function pushAdvantageToWorld(id: number): Promise<void> {
   return invoke<void>('push_advantage_to_world', { id });
+}
+
+/**
+ * Read the bridge's `world_items` snapshot for Foundry, filter to
+ * feature-type items, and write rows into the local advantages
+ * library. Returns the per-row outcome list for the post-import
+ * toast (see `summarizeImport` in `./importer.ts`).
+ *
+ * Caller is responsible for triggering `subscribeToWorldItems()`
+ * first so the bridge cache is populated.
+ */
+export function importAdvantagesFromWorld(): Promise<ImportOutcome[]> {
+  return invoke<ImportOutcome[]>('import_advantages_from_world');
+}
+
+/**
+ * Ask the Foundry module to start streaming world-level Item docs
+ * via `bridge.subscribe { collection: "item" }`. The initial snapshot
+ * arrives as a `bridge://foundry/items-updated` event (see
+ * `src/store/bridge.svelte.ts`); subsequent createItem / updateItem /
+ * deleteItem hook events stream after.
+ */
+export function subscribeToWorldItems(): Promise<void> {
+  return invoke<void>('bridge_subscribe',
+    { source: 'foundry', collection: 'item' });
+}
+
+/**
+ * Stop streaming world-level Item docs. Optional — leaving the
+ * subscription active across sessions is low-cost (the bridge cache
+ * stays warm). Mostly useful for tests / forced re-hydration.
+ */
+export function unsubscribeFromWorldItems(): Promise<void> {
+  return invoke<void>('bridge_unsubscribe',
+    { source: 'foundry', collection: 'item' });
 }

--- a/src/lib/library/api.ts
+++ b/src/lib/library/api.ts
@@ -1,0 +1,14 @@
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * Push a local advantage row → active Foundry world as a world-level
+ * feature Item doc. No-op if Foundry isn't connected (silent success
+ * at the IPC layer; the UI gates the button on bridge connectivity).
+ *
+ * Resolves on success; rejects with a `"tools/library_push: ..."`
+ * string if the advantage id is unknown or the wire envelope fails to
+ * serialize. Bridge-disconnected case is NOT an error.
+ */
+export function pushAdvantageToWorld(id: number): Promise<void> {
+  return invoke<void>('push_advantage_to_world', { id });
+}

--- a/src/lib/library/importer.ts
+++ b/src/lib/library/importer.ts
@@ -1,0 +1,39 @@
+import type { ImportOutcome } from '../../types';
+
+export interface ImportSummary {
+  inserted: number;
+  updated: number;
+  skipped: number;
+  details: ImportOutcome[];
+}
+
+/**
+ * Summarize a list of import outcomes for the UI toast.
+ * Pure; no IPC; no side effects.
+ */
+export function summarizeImport(outcomes: ImportOutcome[]): ImportSummary {
+  let inserted = 0;
+  let updated = 0;
+  let skipped = 0;
+  for (const o of outcomes) {
+    if (o.action === 'inserted') inserted++;
+    else if (o.action === 'updated') updated++;
+    else skipped++;
+  }
+  return { inserted, updated, skipped, details: outcomes };
+}
+
+/**
+ * Format the summary as a single-line toast message.
+ * Example: "Imported 4 new (2 updated, 1 skipped) from Chronicles of Chicago"
+ */
+export function summaryAsToast(summary: ImportSummary, worldTitle: string): string {
+  const parts: string[] = [];
+  parts.push(`Imported ${summary.inserted} new`);
+  const suffixes: string[] = [];
+  if (summary.updated > 0) suffixes.push(`${summary.updated} updated`);
+  if (summary.skipped > 0) suffixes.push(`${summary.skipped} skipped`);
+  if (suffixes.length > 0) parts.push(`(${suffixes.join(', ')})`);
+  parts.push(`from ${worldTitle}`);
+  return parts.join(' ');
+}

--- a/src/store/bridge.svelte.ts
+++ b/src/store/bridge.svelte.ts
@@ -3,13 +3,20 @@
 // the merged character list.
 
 import { listen } from '@tauri-apps/api/event';
-import { getStatus, getCharacters, bridgeGetSourceInfo, type SourceInfo } from '$lib/bridge/api';
-import type { BridgeCharacter, SourceKind } from '../types';
+import {
+  getStatus,
+  getCharacters,
+  bridgeGetSourceInfo,
+  bridgeGetWorldItems,
+  type SourceInfo,
+} from '$lib/bridge/api';
+import type { BridgeCharacter, CanonicalWorldItem, SourceKind } from '../types';
 
 interface BridgeStore {
   connections: Record<SourceKind, boolean>;
   sourceInfo: Record<SourceKind, SourceInfo | null>;
   characters: BridgeCharacter[];
+  worldItems: CanonicalWorldItem[];
   lastSync: Date | null;
 }
 
@@ -17,6 +24,7 @@ export const bridge = $state<BridgeStore>({
   connections: { roll20: false, foundry: false },
   sourceInfo: { roll20: null, foundry: null },
   characters: [],
+  worldItems: [],
   lastSync: null,
 });
 
@@ -46,6 +54,12 @@ export async function initBridge(): Promise<void> {
     console.warn('[bridge] getCharacters failed:', e);
   }
 
+  try {
+    bridge.worldItems = await bridgeGetWorldItems();
+  } catch (e) {
+    console.warn('[bridge] bridgeGetWorldItems failed:', e);
+  }
+
   // Initial fetch — covers the case where the bridge connected before
   // initBridge ran, so the connected listener never fired.
   void refreshSourceInfo('roll20');
@@ -70,6 +84,10 @@ export async function initBridge(): Promise<void> {
     }),
     listen<BridgeCharacter[]>('bridge://characters-updated', (e) => {
       bridge.characters = e.payload;
+      bridge.lastSync = new Date();
+    }),
+    listen<CanonicalWorldItem[]>('bridge://foundry/items-updated', (e) => {
+      bridge.worldItems = e.payload;
       bridge.lastSync = new Date();
     }),
   ]);

--- a/src/tools/AdvantagesManager.svelte
+++ b/src/tools/AdvantagesManager.svelte
@@ -6,9 +6,16 @@
   import AdvantageCard from '$lib/components/AdvantageCard.svelte';
   import AdvantageForm from '$lib/components/AdvantageForm.svelte';
   import { listAdvantages, deleteAdvantage } from '$lib/advantages/api';
+  import {
+    importAdvantagesFromWorld,
+    subscribeToWorldItems,
+  } from '$lib/library/api';
+  import { summarizeImport, summaryAsToast } from '$lib/library/importer';
+  import { bridge } from '../store/bridge.svelte';
   import type { Advantage, Field } from '../types';
 
   type SortKey = 'name-asc' | 'name-desc' | 'level-asc' | 'level-desc' | 'recent';
+  type ProvenanceFilter = 'all' | 'corebook' | 'local' | 'imported';
 
   let allEntries: Advantage[] = $state([]);
   let loading       = $state(true);
@@ -18,8 +25,14 @@
   let searchQuery   = $state('');
   let searchTimer: ReturnType<typeof setTimeout> | null = null;
   let sortKey: SortKey = $state('name-asc');
+  let provenanceFilter: ProvenanceFilter = $state('all');
   let showAddForm   = $state(false);
   let editingId: number | null = $state(null);
+
+  // Pull-from-world transient state. Resets each invocation.
+  let pulling     = $state(false);
+  let pullSummary = $state('');
+  let pullError   = $state('');
 
   // ---- helpers --------------------------------------------------------------
 
@@ -51,6 +64,24 @@
     if (adv.description.toLowerCase().includes(q)) return true;
     if (adv.tags.some(t => t.toLowerCase().includes(q))) return true;
     return false;
+  }
+
+  /**
+   * Tri-state provenance discriminator built from the advantages
+   * `is_custom` tri-state (see ARCH §6):
+   *   - corebook: `is_custom = 0` → reseed-managed.
+   *   - local:    `is_custom = 1 AND source_attribution IS NULL`
+   *               → GM hand-authored, survives reseed.
+   *   - imported: `is_custom = 1 AND source_attribution IS NOT NULL`
+   *               → FVTT-imported, survives reseed.
+   */
+  function matchesProvenance(adv: Advantage): boolean {
+    switch (provenanceFilter) {
+      case 'all':      return true;
+      case 'corebook': return !adv.isCustom;
+      case 'local':    return adv.isCustom && !adv.sourceAttribution;
+      case 'imported': return adv.isCustom && !!adv.sourceAttribution;
+    }
   }
 
   function sortRows(rows: Advantage[]): Advantage[] {
@@ -98,7 +129,9 @@
   }
 
   const visible = $derived(
-    sortRows(allEntries.filter(e => matchesTags(e) && matchesQuery(e)))
+    sortRows(allEntries.filter(e =>
+      matchesTags(e) && matchesQuery(e) && matchesProvenance(e)
+    ))
   );
 
   // ---- actions --------------------------------------------------------------
@@ -149,6 +182,35 @@
     }
   }
 
+  /**
+   * Pull the active Foundry world's feature items into the local
+   * advantages library: subscribe → wait for snapshot → import →
+   * summarize → reload local rows so chips/filter reflect the new
+   * imports.
+   *
+   * The 1.5s wait covers typical Foundry response latency on
+   * localhost. If the bridge cache is already hot (subscribed in a
+   * prior pull this session) the wait is no-cost.
+   */
+  async function pullFromWorld() {
+    pulling = true;
+    pullSummary = '';
+    pullError = '';
+    try {
+      await subscribeToWorldItems();
+      await new Promise(r => setTimeout(r, 1500));
+      const outcomes = await importAdvantagesFromWorld();
+      const summary = summarizeImport(outcomes);
+      const worldTitle = bridge.sourceInfo.foundry?.worldTitle ?? 'Foundry';
+      pullSummary = summaryAsToast(summary, worldTitle);
+      await loadAll();
+    } catch (e) {
+      pullError = String(e);
+    } finally {
+      pulling = false;
+    }
+  }
+
   $effect(() => { untrack(() => loadAll()); });
   $effect(() => { return () => { if (searchTimer) clearTimeout(searchTimer); }; });
 </script>
@@ -174,6 +236,37 @@
     <button class="add-btn" onclick={() => { showAddForm = !showAddForm; editingId = null; }}>
       {showAddForm ? '✕ Cancel' : '+ Add Custom'}
     </button>
+    {#if bridge.connections.foundry}
+      <button
+        class="add-btn pull-btn"
+        disabled={pulling}
+        onclick={pullFromWorld}
+        title="Import feature items from the active Foundry world"
+      >
+        {pulling ? 'Pulling…' : '⇣ Pull from world'}
+      </button>
+    {/if}
+  </div>
+
+  {#if pullSummary || pullError}
+    <div class="pull-status">
+      {#if pullSummary}<span class="pull-summary">{pullSummary}</span>{/if}
+      {#if pullError}<span class="pull-error">{pullError}</span>{/if}
+    </div>
+  {/if}
+
+  <div class="chips provenance-chips" role="group" aria-label="Provenance filter">
+    <button class="chip" class:active={provenanceFilter === 'all'}
+      onclick={() => { provenanceFilter = 'all'; }}>All sources</button>
+    <button class="chip" class:active={provenanceFilter === 'corebook'}
+      data-provenance="corebook"
+      onclick={() => { provenanceFilter = 'corebook'; }}>Corebook</button>
+    <button class="chip" class:active={provenanceFilter === 'local'}
+      data-provenance="local"
+      onclick={() => { provenanceFilter = 'local'; }}>Local</button>
+    <button class="chip" class:active={provenanceFilter === 'imported'}
+      data-provenance="imported"
+      onclick={() => { provenanceFilter = 'imported'; }}>Imported</button>
   </div>
 
   <div class="chips">
@@ -280,6 +373,21 @@
     cursor: pointer;
     white-space: nowrap;
   }
+  .add-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  /* Pull-from-world reuses .add-btn shape but borrows the foundry
+     source-chip accent so the action visually echoes the per-row
+     "FVTT" chip it produces. */
+  .pull-btn {
+    background: var(--bg-card);
+    border-color: var(--accent-foundry, var(--accent-card-dossier));
+    color: var(--accent-foundry, var(--accent-card-dossier));
+  }
+
+  /* Pull status + error toasts — single-line, sit between controls
+     and the chip rows. Cleared on next pull attempt. */
+  .pull-status   { margin: 0 0 0.6rem; font-size: 0.74rem; }
+  .pull-summary  { color: var(--text-secondary); }
+  .pull-error    { color: var(--accent); }
 
   .chips { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 0.75rem; }
   .chip {

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,17 @@ export interface DyscrasiaEntry {
  */
 export type AdvantageKind = 'merit' | 'flaw' | 'background' | 'boon';
 
+/**
+ * Outcome of one import attempt for a single Foundry world item.
+ * Mirrors src-tauri/src/shared/types.rs::ImportOutcome (serde tag
+ * `action`, rename_all snake_case → wire literals 'inserted' /
+ * 'updated' / 'skipped'). Discriminated union; check `action`.
+ */
+export type ImportOutcome =
+  | { action: 'inserted'; id: number; name: string; kind: AdvantageKind }
+  | { action: 'updated';  id: number; name: string; kind: AdvantageKind }
+  | { action: 'skipped';  reason: string; name: string };
+
 export interface Advantage {
   id: number;
   name: string;

--- a/vtmtools-bridge/module.json
+++ b/vtmtools-bridge/module.json
@@ -2,7 +2,7 @@
   "id": "vtmtools-bridge",
   "title": "vtmtools Desktop Bridge",
   "description": "Mirror Foundry actors into the vtmtools desktop app. GM-only; opens a WebSocket to wss://localhost:7424 on world ready.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "authors": [
     {
       "name": "Hampternt",

--- a/vtmtools-bridge/scripts/foundry-actions/bridge.js
+++ b/vtmtools-bridge/scripts/foundry-actions/bridge.js
@@ -9,9 +9,11 @@
 // combat) will register themselves here when their consumer features land.
 
 import { actorsSubscriber } from "./actor.js";
+import { itemsSubscriber } from "./item.js";
 
 const subscribers = {
   actors: actorsSubscriber,
+  item: itemsSubscriber,
 };
 
 const active = new Map(); // collection -> attached subscriber

--- a/vtmtools-bridge/scripts/foundry-actions/item.js
+++ b/vtmtools-bridge/scripts/foundry-actions/item.js
@@ -1,0 +1,67 @@
+// Foundry item.* subscriber executor.
+//
+// World-level Item docs only — embedded-on-actor items continue to flow
+// through actorsSubscriber's per-actor enrichment. The filter is
+// `item.parent === null` on every Foundry Item Document hook event.
+//
+// Wire emission shapes (consumed by Rust FoundryInbound; see
+// src-tauri/src/bridge/foundry/types.rs):
+//   { type: "items",                  items: [...] }    // snapshot on attach
+//   { type: "world_item_upsert",      item: {...} }     // create OR update
+//   { type: "world_item_deleted",     item_id: "..." }  // delete
+
+const MODULE_ID = "vtmtools-bridge";
+
+let _attached = null; // { socket, hookHandles: [ids] }
+
+function itemToWire(item) {
+  return {
+    id: item.id,
+    name: item.name,
+    type: item.type,
+    featuretype: item.system?.featuretype ?? null,
+    system: item.system ?? {},
+  };
+}
+
+function isWorldLevel(item) {
+  // Foundry parents: world items have parent === null; embedded items
+  // have parent === <Actor>.
+  return item.parent === null || item.parent === undefined;
+}
+
+export const itemsSubscriber = {
+  attach(socket) {
+    if (_attached) return;
+    if (socket?.readyState === WebSocket.OPEN) {
+      const items = game.items.contents
+        .filter(isWorldLevel)
+        .map(itemToWire);
+      socket.send(JSON.stringify({ type: "items", items }));
+      console.log(`[${MODULE_ID}] itemsSubscriber: pushed ${items.length} world items`);
+    }
+
+    const onCreate = Hooks.on("createItem", (item /*, options, userId */) => {
+      if (!isWorldLevel(item)) return;
+      socket.send(JSON.stringify({ type: "world_item_upsert", item: itemToWire(item) }));
+    });
+    const onUpdate = Hooks.on("updateItem", (item /*, changes, options, userId */) => {
+      if (!isWorldLevel(item)) return;
+      socket.send(JSON.stringify({ type: "world_item_upsert", item: itemToWire(item) }));
+    });
+    const onDelete = Hooks.on("deleteItem", (item /*, options, userId */) => {
+      if (!isWorldLevel(item)) return;
+      socket.send(JSON.stringify({ type: "world_item_deleted", item_id: item.id }));
+    });
+
+    _attached = { socket, hookHandles: { createItem: onCreate, updateItem: onUpdate, deleteItem: onDelete } };
+  },
+
+  detach() {
+    if (!_attached) return;
+    Hooks.off("createItem", _attached.hookHandles.createItem);
+    Hooks.off("updateItem", _attached.hookHandles.updateItem);
+    Hooks.off("deleteItem", _attached.hookHandles.deleteItem);
+    _attached = null;
+  },
+};

--- a/vtmtools-bridge/scripts/foundry-actions/storyteller.js
+++ b/vtmtools-bridge/scripts/foundry-actions/storyteller.js
@@ -1,2 +1,44 @@
-// Foundry storyteller.* helper executors. Reserved umbrella; no helpers in v1.
-export const handlers = {};
+// Foundry storyteller.* helper executors.
+//
+// World-level operations not tied to a single actor. The storyteller.* umbrella
+// is reserved by name in foundry helper roadmap §5; v1 milestone-4
+// ships exactly one helper: storyteller.create_world_item (used by Library Sync
+// push button to create a Foundry-world-level Item doc that lives in
+// the world's Items sidebar / compendium, not embedded on an actor).
+
+const MODULE_ID = "vtmtools-bridge";
+
+/**
+ * Create a world-level Item document.
+ * Wire shape (validated Rust-side; see build_create_world_item):
+ *   { type: "storyteller.create_world_item", name, featuretype, description, points }
+ * Effect: Item.create({ type: "feature", name,
+ *                       system: { featuretype, description, points } })
+ *         at world level (no parent actor).
+ * Failure modes: Foundry permission errors (GM-only — should not occur
+ *                given the bridge runs in a GM session); duplicate name
+ *                is NOT rejected (Foundry allows duplicate-name items).
+ * Idempotency: NOT idempotent. Re-running creates a duplicate row.
+ *              Dedup is Plan C's concern (auto-version-suffix on pull).
+ */
+async function createWorldItem(msg) {
+  try {
+    await Item.create({
+      type: "feature",
+      name: msg.name,
+      system: {
+        featuretype: msg.featuretype,
+        description: msg.description ?? "",
+        points: typeof msg.points === "number" ? msg.points : 0,
+      },
+    });
+  } catch (err) {
+    console.error(`[${MODULE_ID}] storyteller.create_world_item failed:`, err);
+    ui.notifications?.error(`vtmtools: could not create world item: ${err?.message ?? err}`);
+    throw err;
+  }
+}
+
+export const handlers = {
+  "storyteller.create_world_item": createWorldItem,
+};


### PR DESCRIPTION
## Summary

Phase 4 Library Sync — bidirectional advantage sync between the local library and a Foundry world. Composed of three sequential plans:

- **Plan A — schema foundation:** promotes `tags_json`-based kind discrimination to a real `kind` column (CHECK-gated `merit`/`flaw`/`background`/`boon`); adds nullable `source_attribution` JSON column for FVTT-import provenance; UI gains a per-row kind chip + kind selector. New tri-state `is_custom` invariant in ARCH §6 (corebook reseed-managed / hand-authored local / FVTT-imported).
- **Plan B — push + item subscription:** `push_advantage_to_world` Tauri command + per-row Push button (**closes #13**); new `bridge.subscribe { collection: "item" }` wire path + `bridge://foundry/items-updated` event + `BridgeState.world_items` cache (**closes #27**); new `storyteller.*` outbound umbrella (v1 ships `storyteller.create_world_item` only); `vtmtools-bridge` bumped 0.5.0 → 0.6.0.
- **Plan C — pull + attribution + dedup:** `import_advantages_from_world` Tauri command + Pull button (**closes #14**); per-row source chip _\"FVTT · &lt;world&gt;\"_ on imported rows (**closes #15**); auto-version-suffix dedup _\"(FVTT — &lt;world&gt;)\"_ on cross-world name collisions, keyed on the immutable Foundry document `_id` for re-pull idempotency (**closes #16**); tri-state provenance filter (Corebook / Local / Imported).

Closes #13 #14 #15 #16 #27.

## Architecture changes

- **ARCH §4 IPC inventory:** 5 new commands across Plans B + C (`bridge_get_world_items`, `bridge_subscribe`, `bridge_unsubscribe`, `import_advantages_from_world`, `push_advantage_to_world`); running total 63 → 68.
- **ARCH §4 Bridge protocol:** new `item` subscription collection + `storyteller.*` outbound umbrella documented; new `bridge://foundry/items-updated` events-table row.
- **ARCH §6 invariants:** tri-state `is_custom` semantic.
- **ARCH §9 extensibility seams:** \"Add a library kind\" — partitioning rule (same row shape → polymorphic table with discriminator; different row shape → own table).
- **Migration `0009_advantages_kind_and_source.sql`:** adds the two new columns + backfills `kind` from existing `tags_json`. Safe against the live table (uses `ADD COLUMN … CHECK(…)` + `UPDATE … CASE WHEN`).

## Post-review fix

A single branch-wide code review (Plan C Task 8 Step 4) surfaced one high-confidence bug: the GM-edit path (`update_advantage` Tauri command) was wiping `source_attribution` on every update, which broke the foundryId-keyed re-pull dedup — editing an imported row caused the next pull to re-INSERT it as a duplicate. Fixed in commit `fdccff4` via `SET source_attribution = COALESCE(?, source_attribution)`, with a regression test (`update_preserves_source_attribution_for_imported_rows`) that empirically failed pre-fix and passes post-fix.

## Test plan

Backend + frontend gates are green via `./scripts/verify.sh` (296 cargo tests including 23 new; `npm run check` 0 errors; production build clean). The interactive surfaces below require a live Tauri + Foundry session with `vtmtools-bridge@0.6.0` installed:

### Plan A — schema foundation
- [ ] Fresh dev DB: `sqlite3 ~/.local/share/com.hampternt.vtmtools/vtmtools.db \"SELECT kind, COUNT(*) FROM advantages WHERE is_custom = 0 GROUP BY kind;\"` returns `merit 4`, `background 4`, `flaw 2`.
- [ ] AdvantagesManager renders kind chip per row; kind selector defaults to Merit; saving a custom Boon shows the boon chip color.
- [ ] Restart app → corebook reseeds (kind preserved on rows); custom Boon survives.

### Plan B — push side (#13) + subscription side (#27)
- [ ] Foundry-connected: Push button visible per row; disappears on disconnect.
- [ ] Push corebook merit → appears in Foundry's Items sidebar with `featuretype = merit`.
- [ ] Push each kind (merit / flaw / background / boon) → correct `featuretype` Foundry-side.

### Plan C — pull side (#14, #15, #16)
- [x] In Foundry, manually create a few feature items (one of each kind + one non-feature for the Skipped path).
- [x] Click \"⇣ Pull from world\" → toast: \"Imported N new (M skipped) from &lt;world&gt;\".
- [x] Imported rows show kind chips + \"FVTT · &lt;world&gt;\" source chips.
- [x] Pull again → \"Imported 0 new (N updated, M skipped)\" (idempotency).
- [x] Modify a Foundry-side item description → pull again → row's description updates in place.
- [x] Edit an imported row locally (typo fix) → source chip persists; re-pull → Updated (NOT a duplicate Insert). _(This is the regression case for the `fdccff4` post-review fix.)_
- [x] Cross-world dedup: in a different Foundry world, add a Merit named the same as an existing imported one → pull → new row appears with `(FVTT — <new-world>)` suffix; both rows visible with their respective source chips.
- [x] Tri-state provenance filter (Corebook / Local / Imported) works alongside the existing tag + search filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gk-ai-analysis-start:368d01a0925702f6835509907860f351ca874553 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiSW1wbGVtZW50cyBiaWRpcmVjdGlvbmFsIGFkdmFudGFnZSBzeW5jaW5nIChwdXNoLCBwdWxsLCBkZWR1cGxpY2F0aW9uKSBiZXR3ZWVuIHRoZSBsb2NhbCBsaWJyYXJ5IGFuZCBhIGNvbm5lY3RlZCBGb3VuZHJ5IHdvcmxkLiIsImtleUluc2lnaHRzIjpbeyJ0aXRsZSI6IlByZXNlcnZlcyBzb3VyY2UgYXR0cmlidXRpb24gb24gdXBkYXRlIiwiZGVzY3JpcHRpb24iOiJUaGUgU1FMIFVQREFURSBzdGF0ZW1lbnQgbm93IHVzZXMgQ09BTEVTQ0UgZm9yIHNvdXJjZV9hdHRyaWJ1dGlvbiB0byBwcmV2ZW50IEdNIGVkaXRzIGZyb20gd2lwaW5nIGltcG9ydCBwcm92ZW5hbmNlLCBmaXhpbmcgYSBkZWR1cGxpY2F0aW9uIGJ1Zy4iLCJzZXZlcml0eSI6ImhpZ2giLCJmaWxlUGF0aCI6InNyYy10YXVyaS9zcmMvZGIvYWR2YW50YWdlLnJzIiwibGluZVN0YXJ0IjoxODV9LHsidGl0bGUiOiJGb3VuZHJ5IFdvcmxkIEl0ZW1zIGNhY2hlIGFuZCBzdWJzY3JpcHRpb24iLCJkZXNjcmlwdGlvbiI6IkludHJvZHVjZXMgbmV3IFRhdXJpIGNvbW1hbmRzIGJyaWRnZV9zdWJzY3JpYmUgYW5kIGJyaWRnZV9nZXRfd29ybGRfaXRlbXMgdG8gc3luYyB3b3JsZC1sZXZlbCBGb3VuZHJ5IGl0ZW1zIGludG8gYSBsb2NhbCBjYWNoZS4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoic3JjLXRhdXJpL3NyYy9icmlkZ2UvY29tbWFuZHMucnMiLCJsaW5lU3RhcnQiOjQ2fSx7InRpdGxlIjoiV29ybGQgSXRlbSBVcHNlcnQvRGVsZXRlIEhvb2tzIiwiZGVzY3JpcHRpb24iOiJUaGUgRm91bmRyeSBicmlkZ2UgbW9kdWxlIG5vdyBhdHRhY2hlcyB0byBjcmVhdGVJdGVtLCB1cGRhdGVJdGVtLCBhbmQgZGVsZXRlSXRlbSBob29rcyBzcGVjaWZpY2FsbHkgZm9yIHdvcmxkLWxldmVsIGl0ZW1zICh3aGVyZSBpdGVtLnBhcmVudCBpcyBudWxsKS4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoidnRtdG9vbHMtYnJpZGdlL3NjcmlwdHMvZm91bmRyeS1hY3Rpb25zL2l0ZW0uanMiLCJsaW5lU3RhcnQiOjQ0LCJsaW5lRW5kIjo1NX0seyJ0aXRsZSI6IkxpYnJhcnkgcHVzaCBleHBvcnRzIGxvY2FsIGFkdmFudGFnZXMiLCJkZXNjcmlwdGlvbiI6IkEgbmV3IGxpYnJhcnlfcHVzaCB0b29sIGNvbnN0cnVjdHMgc3Rvcnl0ZWxsZXIgY29tbWFuZHMgdG8gcHVzaCBsb2NhbCBhZHZhbnRhZ2VzIHRvIHRoZSBhY3RpdmUgRm91bmRyeSB3b3JsZCwgY29udmVydGluZyBwb2ludHMgdG8gaW50ZWdlciBib3VuZHMuIiwic2V2ZXJpdHkiOiJtZWRpdW0iLCJmaWxlUGF0aCI6InNyYy10YXVyaS9zcmMvdG9vbHMvbGlicmFyeV9wdXNoLnJzIiwibGluZVN0YXJ0Ijo0OH1dLCJpc3N1ZXMiOltdLCJzdWdnZXN0aW9ucyI6W10sInNlY3VyaXR5IjpbXX0= -->
<!-- gk-ai-analysis-end:368d01a0925702f6835509907860f351ca874553 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/Hampternt/vtmtools/pull/33?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->